### PR TITLE
Abfangen und Umleiten von allen E-Mails

### DIFF
--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/consolidation_email_interceptor')
+
+ActionMailer::Base.register_interceptor ConsolidationEmailInterceptor unless Rails.env.in?(%w[production test])

--- a/config/mailer.sample.yml
+++ b/config/mailer.sample.yml
@@ -1,6 +1,7 @@
 development: &default
   default:
     from: from@example.com
+    interceptions_recipient: interceptions@example.com
   issue_mailer:
     forward:
       subject: weitergeleiteter Vorgang

--- a/lib/consolidation_email_interceptor.rb
+++ b/lib/consolidation_email_interceptor.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ConsolidationEmailInterceptor
+  class << self
+    def delivering_email(message)
+      delivery_method = message.delivery_method
+      return unless delivery_method.is_a? Mail::SMTP
+      return if /true/i.match?(message.header['X-Override-Consolidation'].to_s)
+      message.subject = "#{message.subject} (#{original_recipients message})"
+      message.to = Config.for(:mailer).dig(:default, :interceptions_recipient)
+      message.cc = nil
+      message.bcc = nil
+    end
+
+    private
+
+    def original_recipients(message)
+      { To: message.header['To'], CC: message.header['Cc'], BCC: message.header['Bcc'] }
+        .select { |_, v| v.present? }.map { |k, v| "#{k}: #{v}" }.join ', '
+    end
+  end
+end


### PR DESCRIPTION
In allen Umgebungen außer `test` und `production` werden alle
ausgehenden E-Mails abgefangen und an einen vorgegebenen Empfänger
umgeleitet. Der Empfänger wird in der `config/mailer.yml` unter dem
Schlüssel `default.interceptions_recipient` konfiguriert.

Soll dennoch eine E-Mail tatsächlich gesendet werden, so muss in der
Mail ein Header 'X-Override-Consolidation' mit dem Wert 'true' gesetzt werden.