### PR TITLE
Langschriftliche Bezeichnung nicht als Präfix bei Modell `CountyGroup`

### DIFF
--- a/app/models/county_group.rb
+++ b/app/models/county_group.rb
@@ -2,4 +2,10 @@
 
 class CountyGroup < Group
   belongs_to :county, foreign_key: :reference_id, inverse_of: :groups
+
+  private
+
+  def reference_name
+    county.to_s with_model_name: false
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -65,6 +65,7 @@ class Group < ApplicationRecord
   private
 
   def reference_name
-    send(type.remove(/Group$/).downcase).to_s with_model_name: true
+    send(type.remove(/Group$/).downcase).to_s with_model_name: true unless type == 'CountyGroup'
+    send(type.remove(/Group$/).downcase).to_s with_model_name: false
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -65,7 +65,6 @@ class Group < ApplicationRecord
   private
 
   def reference_name
-    send(type.remove(/Group$/).downcase).to_s with_model_name: true unless type == 'CountyGroup'
-    send(type.remove(/Group$/).downcase).to_s with_model_name: false
+    send(type.remove(/Group$/).downcase).to_s with_model_name: true
   end
 end


### PR DESCRIPTION
Im Kontext von Gruppen soll die langschriftliche Übersetzung des Modells `County` nicht als Präfix für die `CountyGroup` verwenden werden, weil a) einige Landkreise das Wort _Landkreis_ bereits im Titel tragen (Beispiel Landkreis Rostock: Hier stünde dann stets _Landkreis Landkreis Rostock._) und b) es ja auch kreisfreie Städte wie Rostock gibt, bei denen _Landkreis Rostock_ dann eben falsch wäre. Im Pull-Request https://github.com/bfpi/klarschiff-backoffice/pull/70 wird die langschriftliche Bezeichnung des Modells `County` zwar auf _Landkreis/kreisfreie Stadt_ erweitert bzw. korrigiert, aber auch in diesem Zustand stünde am Beispiel des Landkreises Rostock dann _Landkreis/kreisfreie Stadt Landkreis Rostock_ und bei der Stadt Rostock stünde _Landkreis/kreisfreie Stadt Rostock,_ was viel zu lang wäre. Außerdem sind, um es abschließend kurz zu machen, die Titel der Landkreise und kreisfreien Städte so einzigartig, dass man sie auch ohne Präfix als solche erkennt, anderes als etwa bei Ämtern, Gemeinden oder Gemeindeteilen, wo durchaus öfters mal Verwechslungsgefahr besteht.