### PR TITLE
Redmine #3341: große Fotoansicht in neuem Tab/Fenster und Verbesserung E-Mail-Vorlagen

### DIFF
--- a/app/assets/javascripts/issue.coffee.erb
+++ b/app/assets/javascripts/issue.coffee.erb
@@ -76,15 +76,3 @@ $ ->
       success: (data) ->
         open_url = data
     window.open(open_url, '_blank')
-
-  $(document).on 'click', 'tr:not(.active) img.imagezoom', (e) ->
-    e.preventDefault()
-    tr = $(e.target).parents('tr')
-    $('#' + tr.attr('id').replace('_big', '')).hide()
-    $('#' + tr.attr('id') + '_big').show()
-
-  $(document).on 'click', '.image-big img', (e) ->
-    e.preventDefault()
-    tr = $(e.target).parents('tr')
-    $('#' + tr.attr('id').replace('_big', '')).show()
-    $('#' + tr.attr('id')).hide()

--- a/app/assets/javascripts/photos.coffee
+++ b/app/assets/javascripts/photos.coffee
@@ -40,6 +40,10 @@ KS.initializePhotoActions = ->
     row.find('a.stop-edit').show()
     row.find('a.stop-edit ~ a').show(300)
 
+    imagelink = row.find('img.image').parent('a')
+    imagelink.data('link', imagelink.attr('href'))
+    imagelink.removeAttr('href')
+
   $('table#photos tr a.stop-edit').click (event) ->
     event.preventDefault()
     return if (row = $(event.target).parents('tr')).length == 0
@@ -50,6 +54,10 @@ KS.initializePhotoActions = ->
 
     row.find('div.record').children().remove()
     KS.resetPhotoVariables()
+
+    imagelink = row.find('img.image').parent('a')
+    imagelink.attr('href', imagelink.data('link'))
+    imagelink.removeData('link')
 
   $('table#photos tr a.undo').click (event) ->
     event.preventDefault()
@@ -66,7 +74,7 @@ KS.initializePhotoActions = ->
     event.preventDefault()
     return if (row = $(event.target).parents('tr')).length == 0
 
-    picture = row.find('img.imagezoom')
+    picture = row.find('img.image')
     modal = $(picture).parents('.modal-body')
 
     bodyRect = picture[0].getBoundingClientRect()
@@ -92,6 +100,10 @@ KS.initializePhotoActions = ->
     row.find('input.modification').val('censor')
     KS.resetPhotoVariables()
     Rails.fire(row.parents('form')[0], 'submit')
+
+    imagelink = row.find('img.image').parent('a')
+    imagelink.attr('href', imagelink.data('link'))
+    imagelink.removeData('link')
 
   $('table#photos tr a.redo').click (event) ->
     event.preventDefault()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,14 +61,6 @@ nav.navbar {
       margin-right: 1em;
     }
   }
-
-  img {
-    cursor: pointer;
-  }
-
-  .image-big {
-    display: none;
-  }
 }
 
 tr.highlight {

--- a/app/views/issue_mailer/_issue.text.erb
+++ b/app/views/issue_mailer/_issue.text.erb
@@ -1,7 +1,18 @@
-<%= Issue.human_attribute_name :id %><%= "\t\t" %>: <%= issue.id %>
-<%= MainCategory.human_attribute_name :kind %><%= "\t\t" %>: <%= MainCategory.human_enum_name :kind, issue.kind %>
-<%= Category.human_attribute_name :main_category %><%= "\t" %>: <%= issue.main_category %>
-<%= Category.human_attribute_name :sub_category %><%= "\t" %>: <%= issue.sub_category %>
-
+<%= Issue.human_attribute_name :id %>: <%= issue.id %>
+<%= Issue.human_attribute_name :created_at %>: <%= l(issue.created_at, format: :no_seconds) %>
+<%= MainCategory.human_attribute_name :kind %>: <%= MainCategory.human_enum_name :kind, issue.kind %>
+<%= Category.human_attribute_name :main_category %>: <%= issue.main_category %>
+<%= Category.human_attribute_name :sub_category %>: <%= issue.sub_category %>
+<%= Issue.human_attribute_name :status %>: <%= Issue.human_enum_name(:status, issue.status) %>
+<% if issue.status_note.present? -%>
+öffentliche Statusinformation: <%= issue.status_note %>
+<% end -%>
+<% if issue.description.present? -%>
+<%= Issue.human_attribute_name :description %>: <%= issue.description %>
+<% end -%>
+<% if issue.address.present? -%>
+<%= Issue.human_attribute_name :address %>: <%= issue.address %>
+<% end -%>
+<%= Issue.human_attribute_name :group %>: <%= issue.group.name %>
 <% url = local_assigns[:issue_link] ? issue_link : nil -%>
-URL <%= "\t\t" %>: <%= url || Settings::Instance.frontend_issue_url % issue.id %>
+Link: <%= url || Settings::Instance.frontend_issue_url % issue.id %>

--- a/app/views/issue_mailer/delegation.text.erb
+++ b/app/views/issue_mailer/delegation.text.erb
@@ -2,7 +2,7 @@ Sehr geehrte(r) Bearbeiter/-in von Meldungen in <%= Settings::Instance.name %>,
 
 innerhalb der letzten <%= JobSettings::Issue.delegation_deadline_days * 24 %> Stunden wurden Meldungen an Sie delegiert. Bitte bearbeiten Sie diese Meldungen:
 
-Daten der neuen delegierten Meldungen
+Daten der neu an Sie delegierten Meldungen
 ***
 <% @issues.each do |issue| -%>
 <% auth_code = @auth_codes.find { |ac| ac.issue_id == issue.id }.uuid if @auth_codes.present? -%>

--- a/app/views/issues/_tab_photo.html.erb
+++ b/app/views/issues/_tab_photo.html.erb
@@ -33,7 +33,9 @@
               <% end -%>
               <div>
                 <div class="record"></div>
-                <%= image_tag(photo_form.object.file.variant(resize_to_limit: [360, 360]), class: 'imagezoom') %>
+                <%= link_to image_tag(photo_form.object.file.variant(resize_to_limit: [360, 360]), class: 'image'),
+                      photo_form.object.file,
+                      target: '_blank', rel: :noopener %>
               </div>
             </td>
             <td><%= photo_form.object.author %></td>
@@ -62,11 +64,6 @@
                 <%= link_to tag.i('', class: 'fa fa-trash'), '', class: 'btn btn-sm btn-outline-primary delete' %>
               </td>
             <% end -%>
-          </tr>
-          <tr id="photo_<%= photo_form.object.id %>_big" class="image-big">
-            <td colspan="5">
-              <%= image_tag(photo_form.object.file.variant(resize_to_limit: [1100, 1100])) %>
-            </td>
           </tr>
         <% end -%>
       <% end %>
@@ -98,4 +95,3 @@
     </tfoot>
   <% end -%>
 </table>
-<div id="imagezoom-container"></div>


### PR DESCRIPTION
Mit dem ersten Teil (große Fotoansicht in neuem Tab/Fenster) mache ich zwar die Implementierungen zu Redmine #3279 (siehe #99) quasi wieder „kaputt“, aber ich setze etwas an ihre Stelle, was für die Nutzer einen Mehrwert darstellt – diese möchten nämlich tatsächlich die Fotos immer gerne in voller/maximaler Auflösung sehen und gerade deren Öffnen in neuen Tabs/Fenstern finden sie gut.