### PR TITLE
Korrekturen für das Zusammenspiel mit dem DMS d.3

### DIFF
--- a/app/models/dms.rb
+++ b/app/models/dms.rb
@@ -29,13 +29,13 @@ class Dms
   def link
     return if @dms.blank?
     address = Geocodr.address_dms(@issue)
-    @dms[:create_link][@ddc].gsub('{ks_id}', @issue.id.to_s).gsub('{ks_user}', Current.user.login)
-      .gsub('{ks_str}',
-        "#{address['strasse_name']} (#{address['strasse_schluessel']} - #{address['gemeindeteil_name']})")
-      .gsub('{ks_hnr}', address['hausnummer'])
-      .gsub('{ks_hnr_z}', address['hausnummer_zusatz'].presence || '')
-      .gsub('{ks_eigentuemer}',
-        @issue.property_owner.present? ? @issue.property_owner.truncate(254, omission: '…') : '')
+  I18n.interpolate @dms[:create_link][@ddc],
+    ks_id: @issue.id,
+    ks_user: Current.user.login,
+    ks_str: "#{address['strasse_name']} (#{address['strasse_schluessel']} - #{address['gemeindeteil_name']})",
+    ks_hnr: address['hausnummer'],
+    ks_hnr_z: address['hausnummer_zusatz'],
+    ks_eigentuemer: @issue.property_owner.truncate(254, omission: '…') 
   end
 
   private

--- a/app/models/dms.rb
+++ b/app/models/dms.rb
@@ -14,7 +14,7 @@ class Dms
     return false if @dms.blank?
     res = request(:start_search)
     request :close_search
-    Nokogiri::XML(res.body).root.text.to_i == 1
+    res.code.to_i == 200 && Nokogiri::XML(res.body).root.text.to_i == 1
   end
 
   def document_id

--- a/app/models/dms.rb
+++ b/app/models/dms.rb
@@ -29,13 +29,13 @@ class Dms
   def link
     return if @dms.blank?
     address = Geocodr.address_dms(@issue)
-  I18n.interpolate @dms[:create_link][@ddc],
-    ks_id: @issue.id,
-    ks_user: Current.user.login,
-    ks_str: "#{address['strasse_name']} (#{address['strasse_schluessel']} - #{address['gemeindeteil_name']})",
-    ks_hnr: address['hausnummer'],
-    ks_hnr_z: address['hausnummer_zusatz'],
-    ks_eigentuemer: @issue.property_owner.truncate(254, omission: '…') 
+    I18n.interpolate @dms[:create_link][@ddc],
+      ks_id: @issue.id,
+      ks_user: Current.user.login,
+      ks_str: "#{address['strasse_name']} (#{address['strasse_schluessel']} - #{address['gemeindeteil_name']})",
+      ks_hnr: address['hausnummer'],
+      ks_hnr_z: address['hausnummer_zusatz'],
+      ks_eigentuemer: @issue.property_owner.truncate(254, omission: '…')
   end
 
   private

--- a/config/clients.sample.yml
+++ b/config/clients.sample.yml
@@ -4,7 +4,7 @@
 #  create_comments          - Lob/Hinweis/Kritik - lesen /requests/comments/create
 #  create_notes             - interne Kommentare anlegen /requests/notes/create
 #  create_requests          - Vorgang anlegen /requests/create
-#  d3_document_url          - Kategorie-Daten (D.3-Akten-Formular)
+#  d3_document_url          - d.3-Vorgangsformular
 #  destroy_requests         - Vorgang löschen /requests/destroy
 #  read_comments            - Lob/Hinweis/Kritik - lesen /requests/comments/index
 #  read_notes               - interne Kommentare lesen /requests/notes/index

--- a/config/dms.sample.yml
+++ b/config/dms.sample.yml
@@ -1,13 +1,13 @@
 development: &default
   d3:
     api: http://musterstadt-d3-host.org/codiaDMSService/codiaDMSService.asmx
-    close_search: /CloseSearch?strDDC=%{ddc}&strFieldsAndValues=Klarschiff-ID=%{issue_id}
+    close_search: /CloseSearch?strDDC=%{ddc}&strFieldsAndValues=Klarschiff.HRO-ID=%{issue_id}
     create_link:
-      AAUTO: http://musterstadt-d3-host.org/create-link/?ks_id=%{ks_id}&ks_user=%{ks_user}&ks_str=%{ks_str}&ks_hnr=%{ks_hnr}&ks_hnr_z=%{ks_hnr_z}&ks_eigentuemer=%{ks_eigentuemer}
-    get_doc: /GetNthDOKID?strDDC=%{ddc}&strFieldsAndValues=Klarschiff-ID=%{issue_id}&iIndex=1
+      AAUTO: http://musterstadt-d3-host.org/create-link/?ks_id={ks_id}&ks_user={ks_user}&ks_str={ks_str}&ks_hnr={ks_hnr}&ks_hnr_z={ks_hnr_z}&ks_eigentuemer={ks_eigentuemer}
+    get_doc: /GetNthDOKID?strDDC=%{ddc}&strFieldsAndValues=Klarschiff.HRO-ID=%{issue_id}&iIndex=1
     proxy_host:
     proxy_port:
-    start_search: /StartSearch?strDDC=%{ddc}&strFieldsAndValues=Klarschiff-ID=%{issue_id}
+    start_search: /StartSearch?strDDC=%{ddc}&strFieldsAndValues=Klarschiff.HRO-ID=%{issue_id}
 
 alpha: *default
 

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+I18n.config.interpolation_patterns << /\{([\w|]+)\}/ # also match patterns like {key} without leading % before {

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -256,8 +256,8 @@ de:
   delegations: Delegationen
   dms:
     no_doc_id: >-
-      Die d.3-Akte ist zwar vorhanden, jedoch liefert die d.3-API nicht deren Aktennummer zurück,
-      sodass die Akte nicht geöffnet werden kann.
+      Ein d.3-Vorgang ist zwar anscheinend vorhanden, jedoch liefert die d.3-API nicht dessen Vorgangsnummer zurück,
+      sodass der d.3-Vorgang nicht geöffnet werden kann.
   edit: bearbeiten
   edit_issue: Meldung bearbeiten
   editorial_notifications:


### PR DESCRIPTION
* Prüfung korrigiert, ob _d.3_-Vorgang vorhanden ist oder nicht: Hier muss geprüft werden, ob das XML im Ergebnis von `StartSearch` tatsächlich eine `1` liefert und nicht nur, ob `StartSearch` einen HTTP-Statuscode 200 zurückliefert.
* dynamisches Setzen der URL-Parameter für das _d.3_-Vorgangsformular korrigiert: Die `%{}`-Syntax kann hier nicht verwendet werden, da die URL ja auch via CitySDK an den Client übergeben wird, der wiederum seinereits die URL-Parameter dynamisch setzen. Daher musste auf `{}`-Syntax umgestiegen werden, sodass das dynamische Setzen der URL-Parameter nun – äquivalent zum Client – via `gsub` geschieht.