### PR TITLE
Status-Filter

### DIFF
--- a/app/models/issue_filter.rb
+++ b/app/models/issue_filter.rb
@@ -38,6 +38,7 @@ class IssueFilter
   end
 
   def extended_filter(params)
+    params[:statuses] = Issue.statuses.values if params[:statuses].blank?
     params.each do |key, value|
       send("filter_#{key}", params) if respond_to?("filter_#{key}", true) && value.present?
     end

--- a/app/views/issues/_extended_filter.html.erb
+++ b/app/views/issues/_extended_filter.html.erb
@@ -38,7 +38,7 @@
     <div class="col-4">
       <div class="row">
         <% Issue.statuses.each do |name, id| -%>
-          <%= label_tag "filter_statuses_#{name}", class: 'col-12 col-form-label' do %>
+          <%= label_tag "statuses_#{name}", class: 'col-12 col-form-label' do %>
             <%= check_box_tag 'filter[statuses][]', id, id.in?(@filter[:statuses].map(&:to_i)),
                   id: "statuses_#{name}" %>
             <%= t("enums.issue.status.#{name}") %>


### PR DESCRIPTION
Fixes <ActionView::Template::Error: undefined method `map' for nil:NilClass> in app/views/issues/_extended_filter.html.erb:42
der auftritt wenn man im Filter alle Status abwählt