### PR TITLE
Wartezeit für Rendern der Karte für den PDF-Export erhöht

### DIFF
--- a/app/assets/javascripts/issue.coffee.erb
+++ b/app/assets/javascripts/issue.coffee.erb
@@ -47,7 +47,7 @@ $ ->
 
       $('#map').html('')
       KS.initializeMaps(true)
-    ), 1000
+    ), 3000
 
   $(document).on 'click', '.card .btn-create', (e) ->
     e.preventDefault()


### PR DESCRIPTION
Bei langsamer Netzverbindung dauert das Rendern der Karte u.U. etwas länger. Falls die Karte noch nicht vollständig gerendert ist, wird sie nicht korrekt in der PDF angezeigt.