### PR TITLE
Redmine #3485: beim Mapping zwischen CitySDK-detailed_status und Klars…

### DIFF
--- a/app/models/citysdk/request_setter.rb
+++ b/app/models/citysdk/request_setter.rb
@@ -9,7 +9,7 @@ module Citysdk
         errors.add :status, :invalid
         raise ActiveRecord::RecordInvalid, self
       end
-      return if (new_status = Citysdk::Status::CITYSDK[value]).blank?
+      return if (new_status = Citysdk::Status::CITYSDK_WRITE[value]).blank?
       self.status = new_status
     end
 

--- a/app/models/citysdk/status.rb
+++ b/app/models/citysdk/status.rb
@@ -12,6 +12,12 @@ module Citysdk
                                 %w[duplicate not_solvable]
                               end }.freeze
 
+    CITYSDK_WRITE = {
+      'IN_PROCESS' => defined?(STATUS_CITYSDK_IN_PROCESS) ? STATUS_CITYSDK_IN_PROCESS : 'in_process',
+      'PROCESSED' => defined?(STATUS_CITYSDK_PROCESSED) ? STATUS_CITYSDK_PROCESSED : 'closed',
+      'REJECTED' => defined?(STATUS_CITYSDK_REJECTED) ? STATUS_CITYSDK_REJECTED : 'not_solvable'
+    }.freeze
+
     PERMISSABLE_CITYSDK_KEYS = %w[IN_PROCESS PROCESSED REJECTED].freeze
 
     OPEN311 = { 'open' => (if defined?(STATUS_OPEN311_OPEN)

--- a/test/controllers/citysdk/requests_controller_test.rb
+++ b/test/controllers/citysdk/requests_controller_test.rb
@@ -316,6 +316,15 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_error_messages doc, '422', 'Gültigkeitsprüfung ist fehlgeschlagen'
   end
 
+  test 'update attribute detailed_status as rejected with ppc api-key' do
+    issue = issue(:in_process)
+    new_value = 'REJECTED'
+    reloaded_request = update_request_and_reload(issue.id, :detailed_status, new_value)
+    assert_equal 'not_solvable', issue.reload.status
+    assert_equal new_value,
+      reloaded_request.xpath('/service_requests/request/extended_attributes/detailed_status/text()').first.to_s
+  end
+
   test 'update attribute job_priority with ppc api-key' do
     new_value = '4'
     reloaded_request = update_request_and_reload(issue(:one).id, :job_priority, new_value)


### PR DESCRIPTION
…chiff-Status differenzieren zwischen Lese- und Schreibmodus