### PR TITLE
Ehemalige Meldungen über Gruppen-IDs aus dem Logbuch bestimmen

### DIFF
--- a/db/migrate/20220420110613_add_attributes_to_log_entry.rb
+++ b/db/migrate/20220420110613_add_attributes_to_log_entry.rb
@@ -4,7 +4,7 @@ class AddAttributesToLogEntry < ActiveRecord::Migration[6.1]
   def change
     change_table :log_entry, bulk: true do |t|
       t.bigint :old_value_id
-      t.bigint :new_value_id
+      t.bigint :new_value_id, index: true
     end
   end
 end

--- a/db/migrate/20220420110613_add_attributes_to_log_entry.rb
+++ b/db/migrate/20220420110613_add_attributes_to_log_entry.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddAttributesToLogEntry < ActiveRecord::Migration[6.1]
+  def change
+    change_table :log_entry, bulk: true do |t|
+      t.bigint :old_value_id
+      t.bigint :new_value_id
+    end
+  end
+end

--- a/db/migrate/20220420114233_add_value_ids_to_group_change_log_entries.rb
+++ b/db/migrate/20220420114233_add_value_ids_to_group_change_log_entries.rb
@@ -13,8 +13,8 @@ class AddValueIdsToGroupChangeLogEntries < ActiveRecord::Migration[6.1]
   private
 
   def add_group_ids!(entry, groups)
-    old_group = find_group(entry.old_value, groups) 
-    new_group = find_group(entry.new_value, groups) 
+    old_group = find_group(entry.old_value, groups)
+    new_group = find_group(entry.new_value, groups)
     entry.update!(old_value_id: old_group&.id, new_value_id: new_group&.id)
     error_logs(entry, old_group, new_group)
   end
@@ -30,14 +30,14 @@ class AddValueIdsToGroupChangeLogEntries < ActiveRecord::Migration[6.1]
 
   def find_group(value, groups)
     return if value.blank?
-    group = Group.find_by(gat[:short_name].eq(value).or(gat[:name].eq(value)))
+    group = groups.find_by(gat[:short_name].eq(value).or(gat[:name].eq(value)))
     return group if group
     value = cut_group_name(value)
-    Group.find_by(gat[:short_name].eq(value).or(gat[:name].eq(value)))
+    groups.find_by(gat[:short_name].eq(value).or(gat[:name].eq(value)))
   end
 
   def cut_group_name(name)
-    name.remove(/\([^\(\)]+\)$/).strip
+    name.remove(/\([^()]+\)$/).strip
   end
 
   def gat

--- a/db/migrate/20220420114233_add_value_ids_to_group_change_log_entries.rb
+++ b/db/migrate/20220420114233_add_value_ids_to_group_change_log_entries.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class AddValueIdsToGroupChangeLogEntries < ActiveRecord::Migration[6.1]
+  def up
+    LogEntry.where(table: 'issue', attr: 'group').find_each do |entry|
+      groups = Group.regional(lat: entry.issue.position.y, lon: entry.issue.position.x)
+      add_group_ids!(entry, groups)
+    end
+  end
+
+  def down; end
+
+  private
+
+  def add_group_ids!(entry, groups)
+    old_group = find_group(entry.old_value, groups) 
+    new_group = find_group(entry.new_value, groups) 
+    entry.update!(old_value_id: old_group&.id, new_value_id: new_group&.id)
+    error_logs(entry, old_group, new_group)
+  end
+
+  def error_logs(entry, old_group, new_group)
+    error_message(entry.old_value, entry.id) if entry.old_value.present? && old_group.blank?
+    error_message(entry.new_value, entry.id) if entry.new_value.present? && new_group.blank?
+  end
+
+  def error_message(value, id)
+    Rails.logger.error "LogEntry ##{id}: Gruppe \"#{value}\" konnte nicht gefunden werden"
+  end
+
+  def find_group(value, groups)
+    return if value.blank?
+    group = Group.find_by(gat[:short_name].eq(value).or(gat[:name].eq(value)))
+    return group if group
+    value = cut_group_name(value)
+    Group.find_by(gat[:short_name].eq(value).or(gat[:name].eq(value)))
+  end
+
+  def cut_group_name(name)
+    name.remove(/\([^\(\)]+\)$/).strip
+  end
+
+  def gat
+    Group.arel_table
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -256,6 +256,7 @@ ActiveRecord::Schema.define(version: 2022_04_20_114233) do
     t.index ["attr"], name: "index_log_entry_on_attr"
     t.index ["auth_code_id"], name: "index_log_entry_on_auth_code_id"
     t.index ["issue_id"], name: "index_log_entry_on_issue_id"
+    t.index ["new_value_id"], name: "index_log_entry_on_new_value_id"
     t.index ["table", "subject_id"], name: "index_log_entry_on_table_and_subject_id"
     t.index ["user_id"], name: "index_log_entry_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_22_122924) do
+ActiveRecord::Schema.define(version: 2022_04_20_114233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -214,6 +214,7 @@ ActiveRecord::Schema.define(version: 2022_02_22_122924) do
     t.bigint "job_id"
     t.bigint "updated_by_user_id"
     t.bigint "updated_by_auth_code_id"
+    t.datetime "last_notification"
     t.datetime "group_responsibility_notified_at"
     t.index ["archived_at"], name: "index_issue_on_archived_at"
     t.index ["category_id"], name: "index_issue_on_category_id"
@@ -250,6 +251,8 @@ ActiveRecord::Schema.define(version: 2022_02_22_122924) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
     t.bigint "auth_code_id"
+    t.bigint "old_value_id"
+    t.bigint "new_value_id"
     t.index ["attr"], name: "index_log_entry_on_attr"
     t.index ["auth_code_id"], name: "index_log_entry_on_auth_code_id"
     t.index ["issue_id"], name: "index_log_entry_on_issue_id"
@@ -334,6 +337,7 @@ ActiveRecord::Schema.define(version: 2022_02_22_122924) do
     t.datetime "updated_at", precision: 6, null: false
     t.json "password_history"
     t.datetime "password_updated_at"
+    t.boolean "notification_recipient", default: false, null: false
     t.boolean "group_responsibility_recipient", default: false, null: false
   end
 

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -10,8 +10,12 @@ class DashboardsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [issue(:former_issue_one).id], @controller.view_assigns['former_issues'].ids
   end
 
-  test 'show no former issues for admin' do
+  test 'show no former issues for admin without groups' do
     login username: :admin
+    get '/dashboards'
+    assert_response :success
+    assert_equal [issue(:former_issue_one).id], @controller.view_assigns['former_issues'].ids
+    user(:admin).update! groups: []
     get '/dashboards'
     assert_response :success
     assert_empty @controller.view_assigns['former_issues']

--- a/test/fixtures/log_entry.yml
+++ b/test/fixtures/log_entry.yml
@@ -66,7 +66,9 @@ group_changed_one:
   created_at: <%= Time.current - 12.hours %>
   issue: former_issue_one
   new_value: two
+  new_value_id: <%= ActiveRecord::FixtureSet.identify :two %>
   old_value: internal
+  old_value_id: <%= ActiveRecord::FixtureSet.identify :internal %>
   subject_id: <%= ActiveRecord::FixtureSet.identify :former_issue_one %>
   subject_name: Test
   table: issue
@@ -78,7 +80,9 @@ group_changed_two:
   created_at: <%= Time.current - 14.hours %>
   issue: former_issue_one
   new_value: internal
+  new_value_id: <%= ActiveRecord::FixtureSet.identify :internal %>
   old_value:
+  old_value_id:
   subject_id: <%= ActiveRecord::FixtureSet.identify :former_issue_one %>
   subject_name: Test
   table: issue
@@ -90,7 +94,9 @@ group_changed_three:
   created_at: <%= Time.current - 12.hours %>
   issue: former_issue_two
   new_value: one
+  new_value_id: <%= ActiveRecord::FixtureSet.identify :one %>
   old_value: internal2
+  old_value_id: <%= ActiveRecord::FixtureSet.identify :internal2 %>
   subject_id: <%= ActiveRecord::FixtureSet.identify :former_issue_one %>
   subject_name: Test
   table: issue
@@ -102,7 +108,9 @@ group_changed_four:
   created_at: <%= Time.current - 14.hours %>
   issue: former_issue_two
   new_value: internal2
+  new_value_id: <%= ActiveRecord::FixtureSet.identify :internal2 %>
   old_value:
+  old_value_id:
   subject_id: <%= ActiveRecord::FixtureSet.identify :former_issue_two %>
   subject_name: Test
   table: issue


### PR DESCRIPTION
Bisher werden die ehemaligen Meldungen über die Namen der Gruppen aus dem Logbuch identifiziert. Das scheitert jedoch in dem Moment wo der Name einer Gruppe geändert wird. Danach können die ehemaligen Meldungen nicht mehr über den Gruppennamen gefunden werden. Daher ist der Weg über die nicht veränderbare Gruppen-ID notwendig!