### PR TITLE
Redmine #2753: API-/Schnittstellen-Dokumentation CitySDK

### DIFF
--- a/.github/workflows/citysdk_apidoc.yml
+++ b/.github/workflows/citysdk_apidoc.yml
@@ -1,0 +1,20 @@
+name: Update CitySDK API documentation
+
+on: [pull_request]
+
+jobs:
+  update-api:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Create CitySDK API documentation
+        run: bundle exec rails citysdk:apidoc
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update CitySDK API documentation
+          file_pattern: CitySDK_API.md

--- a/.github/workflows/citysdk_apidoc.yml
+++ b/.github/workflows/citysdk_apidoc.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+      - name: Prepare Config
+        run: |
+          rm config/database.yml
+          cp config/database.sample.yml config/database.yml
+          rm config/secrets.yml
+          cp config/secrets.sample.yml config/secrets.yml
+          rm config/storage.yml
+          cp config/storage.sample.yml config/storage.yml
+
       - name: Create CitySDK API documentation
         run: bundle exec rails citysdk:apidoc
 

--- a/.github/workflows/citysdk_apidoc.yml
+++ b/.github/workflows/citysdk_apidoc.yml
@@ -11,6 +11,11 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
       - name: Create CitySDK API documentation
         run: bundle exec rails citysdk:apidoc
 

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -196,6 +196,7 @@ Sample Response:
 ```
 ### Update Service request
 <code>PATCH http://[API endpoint]/requests/[service_request_id].[format]</code>
+
 <code>PUT   http://[API endpoint]/requests/[service_request_id].[format]</code>
 
 Parameters:

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -91,8 +91,8 @@ Parameters:
 | observation_key | - | String | MD5 hash of observed area to use as filter |
 | area_code | - | Integer | Filter issues by affected area ID |
 
-Available Open311 states: `open`, `closed`
-Available CitySDK states: `PENDING`, `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
+Available Open311 states for this action: `open`, `closed`\
+Available CitySDK states for this action: `PENDING`, `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
 
 Sample Response:
 
@@ -301,7 +301,9 @@ Parameters:
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
 | date | X | Date | Filter jobs that are the equal or lower than the given date |
-| status | - | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+| status | - | String | Job status |
+
+Available job states for this action: `CHECKED`, `UNCHECKED`, `NOT_CHECKABLE`
 
 Sample Response:
 
@@ -343,8 +345,10 @@ Sample Response:
 </jobs>
 ```
 ### Update job
-<code>PATCH http://[API endpoint]/jobs/[service_request_id].[format]</code>
-<code>PUT   http://[API endpoint]/jobs/[service_request_id].[format]</code>
+```
+PATCH http://[API endpoint]/jobs/[service_request_id].[format]
+PUT   http://[API endpoint]/jobs/[service_request_id].[format]
+```
 
 Parameters:
 
@@ -352,8 +356,10 @@ Parameters:
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
 | service_request_id | X | Integer | Affected issue ID |
-| status | X | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+| status | X | String | Job status |
 | date | X | Date | Date of job |
+
+Available job states for this action: `CHECKED`, `UNCHECKED`, `NOT_CHECKABLE`
 
 Sample Response:
 
@@ -386,7 +392,7 @@ Parameters:
 | idea_service | | String | Filter ideas by main category IDs |
 | idea_service_sub | | String | Filter ideas by sub category IDs |
 
-*: Either geometry or area_code is required
+*: Either `geometry` or `area_code` is required
 
 Sample Response:
 

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -12,154 +12,54 @@ To support some special functions there are also some additional enhancements to
 
 ## API methods
 
-### Get observable areas
-<code>GET http://[API endpoint]/areas.[format]</code>
-
-Parameters:
-
-| Name | Required | Type | Notes |
-|:--|:-:|:--|:--|
-| api_key | X | String | API key |
-| area_code | - | Integer[] | IDs to filter districts |
-| with_districts | - | Boolean | return all existing districts, not available if using area_code |
-
-Sample Response:
-
-```xml
-<areas>
-<area>
-<id>30</id>
-<name>Biestow</name>
-<grenze>MULTIPOLYGON (((...)))</grenze>
-</area>
-...
-</areas>
-```
-
-### Get position coverage
-<code>GET http://[API endpoint]/coverage.[format]</code>
-
-Parameters:
-
-| Name | Required | Type | Notes |
-|:--|:-:|:--|:--|
-| api_key | X | String | API key |
-| lat | X | Float | latitude value |
-| long | X | Float | longitude value |
-
-Sample Response:
-
-```xml
-<hash>
-<result type="boolean">false</result>
-</hash>
-```
-
 ### Get discovery
 <code>GET http://[API endpoint]/discovery.[format]</code>
 
-### Get jobs list
-<code>GET http://[API endpoint]/jobs.[format]</code>
+### GET services list
+<code>GET http://[API endpoint]/services.[format]</code>
 
 Parameters:
 
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
-| api_key | X | String | API key |
-| date | X | Date | Filter jobs that are the equal or lower than the given date |
-| status | - | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+| api_key | - | String | API key |
 
 Sample Response:
 
 ```xml
-<jobs>
-<job>
-<id>job.id</id>
-<service-request-id>job.service_request_id</service-request-id>
-<date>job.date</date>
-<agency-responsible>job.agency_responsible</agency-responsible>
-<status>job.status</status>
-</job>
-...
-</jobs>
+<services type="array">
+  <service>
+    <service_code>category.id</service_code>
+    <service_name>category.name</service_name>
+    <description/>
+    <metadata>false</metadata>
+    <type>realtime</type>
+    <keywords>category.parent.typ [problem|idee|tipp]</keywords>
+    <group>category.parent.name</group>
+  </service>
+</services>
 ```
-### Create new job
-<code>POST http://[API endpoint]/jobs.[format]</code>
+### Get service definition
+<code>GET http://[API endpoint]/services/[id].[format]</code>
 
 Parameters:
 
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
-| api_key | X | String | API key |
-| service_request_id | X | Integer | Affected issue ID |
-| agency_responsible | X | String | Name of team |
-| date | X | Date | Date for job |
+| api_key | - | String | API key |
+| id | X | Integer | ID of service|
 
 Sample Response:
 
 ```xml
-<jobs>
-<job>
-<id>job.id</id>
-<service-request-id>job.service_request_id</service-request-id>
-<date>job.date</date>
-<agency-responsible>job.agency_responsible</agency-responsible>
-<status>job.status</status>
-</job>
-</jobs>
-```
-### Update job
-<code>PATCH http://[API endpoint]/jobs/[service_request_id].[format]</code>
-<code>PUT   http://[API endpoint]/jobs/[service_request_id].[format]</code>
-
-Parameters:
-
-| Name | Required | Type | Notes |
-|:--|:-:|:--|:--|
-| api_key | X | String | API key |
-| service_request_id | X | Integer | Affected issue ID |
-| status | X | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
-| date | X | Date | Date of job |
-
-Sample Response:
-
-```xml
-<jobs>
-<job>
-<id>job.id</id>
-<service-request-id>job.service_request_id</service-request-id>
-<date>job.date</date>
-<agency-responsible>job.agency_responsible</agency-responsible>
-<status>job.status</status>
-</job>
-</jobs>
-```
-
-### Create new observation
-<code>POST http://[API endpoint]/observations.[format]</code>
-
-Parameters:
-
-| Name | Required | Type | Notes |
-|:--|:-:|:--|:--|
-| api_key | X | String | API key |
-| geometry | * | String | WKT geoemetry for observing area |
-| area_code | * | String | IDs of districts, -1 for instance |
-| problems | - | Boolean | Include problems |
-| problem_service | - | String | Filter problems by main category IDs |
-| problem_service_sub | - | String | Filter problems by sub category IDs |
-| ideas | - | Boolean | Include problems |
-| idea_service | | String | Filter ideas by main category IDs |
-| idea_service_sub | | String | Filter ideas by sub category IDs |
-
-*: Either geometry or area_code is required
-
-Sample Response:
-
-```xml
-<observation>
-<rss-id>39a855f0a4924af3217a217c8dc78ece</rss-id>
-</observatio>
+<service_definition type="array">
+  <service>
+    <service_code>category.id</service_code>
+    <service_name>category.name</service_name>
+    <keywords>category.parent.typ [problem|idee|tipp]</keywords>
+    <group>category.parent.name</group>
+  </service>
+</service_definition>
 ```
 
 ### Get service requests list
@@ -198,25 +98,25 @@ Sample Response:
 
 ```xml
 <service_requests type="array">
-<request>
-<service_request_id>request.id</service_request_id>
-<status_notes/>
-<status>request.status</status>
-<service_code>request.service.code</service_code>
-<service_name>request.service.name</service_name>
-<description>request.description</description>
-<agency_responsible>request.agency_responsible</agency_responsible>
-<service_notice/>
-<requested_datetime>request.requested_datetime</requested_datetime>
-<updated_datetime>request.updated_datetime</updated_datetime>
-<expected_datetime/>
-<address>request.address</address>
-<adress_id/>
-<lat>request.position.lat</lat>
-<long>request.position.lat</long>
-<media_url/>
-<zipcode/>
-</request>
+  <request>
+    <service_request_id>request.id</service_request_id>
+    <status_notes/>
+    <status>request.status</status>
+    <service_code>request.service.code</service_code>
+    <service_name>request.service.name</service_name>
+    <description>request.description</description>
+    <agency_responsible>request.agency_responsible</agency_responsible>
+    <service_notice/>
+    <requested_datetime>request.requested_datetime</requested_datetime>
+    <updated_datetime>request.updated_datetime</updated_datetime>
+    <expected_datetime/>
+    <address>request.address</address>
+    <adress_id/>
+    <lat>request.position.lat</lat>
+    <long>request.position.lat</long>
+    <media_url/>
+    <zipcode/>
+  </request>
 </service_requests>
 ```
 
@@ -235,34 +135,34 @@ Sample Response:
 
 ```xml
 <service_requests type="array">
-<request>
-<service_request_id>request.id</service_request_id>
-<status_notes/>
-<status>request.status</status>
-<service_code>request.service.code</service_code>
-<service_name>request.service.name</service_name>
-<description>request.description</description>
-<agency_responsible>request.agency_responsible</agency_responsible>
-<service_notice/>
-<requested_datetime>request.requested_datetime</requested_datetime>
-<updated_datetime>request.updated_datetime</updated_datetime>
-<expected_datetime/>
-<address>request.address</address>
-<adress_id/>
-<lat>request.position.lat</lat>
-<long>request.position.lat</long>
-<media_url/>
-<zipcode/>
-<extended_attributes>
-<detailed_status>request.detailed_status</detailed_status>
-<media_urls>
-<media_url>request.media.url</media_url>
-</media_urls>
-<photo_required>request.photo_required</photo_required>
-<trust>request.trust</trust>
-<votes>request.votes</votes>
-</extended_attributes>
-</request>
+  <request>
+    <service_request_id>request.id</service_request_id>
+    <status_notes/>
+    <status>request.status</status>
+    <service_code>request.service.code</service_code>
+    <service_name>request.service.name</service_name>
+    <description>request.description</description>
+    <agency_responsible>request.agency_responsible</agency_responsible>
+    <service_notice/>
+    <requested_datetime>request.requested_datetime</requested_datetime>
+    <updated_datetime>request.updated_datetime</updated_datetime>
+    <expected_datetime/>
+    <address>request.address</address>
+    <adress_id/>
+    <lat>request.position.lat</lat>
+    <long>request.position.lat</long>
+    <media_url/>
+    <zipcode/>
+    <extended_attributes>
+      <detailed_status>request.detailed_status</detailed_status>
+      <media_urls>
+        <media_url>request.media.url</media_url>
+      </media_urls>
+      <photo_required>request.photo_required</photo_required>
+      <trust>request.trust</trust>
+      <votes>request.votes</votes>
+    </extended_attributes>
+  </request>
 </service_requests>
 ```
 ### Create service request
@@ -289,9 +189,9 @@ Sample Response:
 
 ```xml
 <service_requests>
-<request>
-<service_request_id>request.id</service_request_id>
-</request>
+  <request>
+    <service_request_id>request.id</service_request_id>
+  </request>
 </service_requests>
 ```
 ### Update Service request
@@ -324,72 +224,172 @@ Sample Response:
 
 ```xml
 <service_requests type="array">
-<request>
-<service_request_id>request.id</service_request_id>
-<status_notes/>
-<status>request.status</status>
-<service_code>request.service.code</service_code>
-<service_name>request.service.name</service_name>
-<description>request.description</description>
-<agency_responsible>request.agency_responsible</agency_responsible>
-<service_notice/>
-<requested_datetime>request.requested_datetime</requested_datetime>
-<updated_datetime>request.updated_datetime</updated_datetime>
-<expected_datetime/>
-<address>request.address</address>
-<adress_id/>
-<lat>request.position.lat</lat>
-<long>request.position.lat</long>
-<media_url/>
-<zipcode/>
-</request>
+  <request>
+    <service_request_id>request.id</service_request_id>
+    <status_notes/>
+    <status>request.status</status>
+    <service_code>request.service.code</service_code>
+    <service_name>request.service.name</service_name>
+    <description>request.description</description>
+    <agency_responsible>request.agency_responsible</agency_responsible>
+    <service_notice/>
+    <requested_datetime>request.requested_datetime</requested_datetime>
+    <updated_datetime>request.updated_datetime</updated_datetime>
+    <expected_datetime/>
+    <address>request.address</address>
+    <adress_id/>
+    <lat>request.position.lat</lat>
+    <long>request.position.lat</long>
+    <media_url/>
+    <zipcode/>
+  </request>
 </service_requests>
 ```
 
-### GET services list
-<code>GET http://[API endpoint]/services.[format]</code>
+### Get observable areas
+<code>GET http://[API endpoint]/areas.[format]</code>
 
 Parameters:
 
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
-| api_key | - | String | API key |
+| api_key | X | String | API key |
+| area_code | - | Integer[] | IDs to filter districts |
+| with_districts | - | Boolean | return all existing districts, not available if using area_code |
 
 Sample Response:
 
 ```xml
-<services type="array">
-<service>
-<service_code>category.id</service_code>
-<service_name>category.name</service_name>
-<description/>
-<metadata>false</metadata>
-<type>realtime</type>
-<keywords>category.parent.typ [problem|idee|tipp]</keywords>
-<group>category.parent.name</group>
-</service>
-</services>
+<areas>
+  <area>
+    <id>30</id>
+    <name>Biestow</name>
+    <grenze>MULTIPOLYGON (((...)))</grenze>
+  </area>
+  ...
+</areas>
 ```
-### Get service definition
-<code>GET http://[API endpoint]/services/[id].[format]</code>
+
+### Get position coverage
+<code>GET http://[API endpoint]/coverage.[format]</code>
 
 Parameters:
 
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
-| api_key | - | String | API key |
-| id | X | Integer | ID of service|
+| api_key | X | String | API key |
+| lat | X | Float | latitude value |
+| long | X | Float | longitude value |
 
 Sample Response:
 
 ```xml
-<service_definition type="array">
-<service>
-<service_code>category.id</service_code>
-<service_name>category.name</service_name>
-<keywords>category.parent.typ [problem|idee|tipp]</keywords>
-<group>category.parent.name</group>
-</service>
-</service_definition>
+<hash>
+  <result type="boolean">false</result>
+</hash>
+```
+
+### Get jobs list
+<code>GET http://[API endpoint]/jobs.[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| date | X | Date | Filter jobs that are the equal or lower than the given date |
+| status | - | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+
+Sample Response:
+
+```xml
+<jobs>
+  <job>
+    <id>job.id</id>
+    <service-request-id>job.service_request_id</service-request-id>
+    <date>job.date</date>
+    <agency-responsible>job.agency_responsible</agency-responsible>
+    <status>job.status</status>
+  </job>
+  ...
+</jobs>
+```
+### Create new job
+<code>POST http://[API endpoint]/jobs.[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| service_request_id | X | Integer | Affected issue ID |
+| agency_responsible | X | String | Name of team |
+| date | X | Date | Date for job |
+
+Sample Response:
+
+```xml
+<jobs>
+  <job>
+    <id>job.id</id>
+    <service-request-id>job.service_request_id</service-request-id>
+    <date>job.date</date>
+    <agency-responsible>job.agency_responsible</agency-responsible>
+    <status>job.status</status>
+  </job>
+</jobs>
+```
+### Update job
+<code>PATCH http://[API endpoint]/jobs/[service_request_id].[format]</code>
+<code>PUT   http://[API endpoint]/jobs/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| service_request_id | X | Integer | Affected issue ID |
+| status | X | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+| date | X | Date | Date of job |
+
+Sample Response:
+
+```xml
+<jobs>
+  <job>
+    <id>job.id</id>
+    <service-request-id>job.service_request_id</service-request-id>
+    <date>job.date</date>
+    <agency-responsible>job.agency_responsible</agency-responsible>
+    <status>job.status</status>
+  </job>
+</jobs>
+```
+
+### Create new observation
+<code>POST http://[API endpoint]/observations.[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| geometry | * | String | WKT geoemetry for observing area |
+| area_code | * | String | IDs of districts, -1 for instance |
+| problems | - | Boolean | Include problems |
+| problem_service | - | String | Filter problems by main category IDs |
+| problem_service_sub | - | String | Filter problems by sub category IDs |
+| ideas | - | Boolean | Include problems |
+| idea_service | | String | Filter ideas by main category IDs |
+| idea_service_sub | | String | Filter ideas by sub category IDs |
+
+*: Either geometry or area_code is required
+
+Sample Response:
+
+```xml
+<observation>
+  <rss-id>39a855f0a4924af3217a217c8dc78ece</rss-id>
+</observatio>
 ```
 

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -195,9 +195,10 @@ Sample Response:
 </service_requests>
 ```
 ### Update Service request
-<code>PATCH http://[API endpoint]/requests/[service_request_id].[format]</code>
-
-<code>PUT   http://[API endpoint]/requests/[service_request_id].[format]</code>
+```
+PATCH http://[API endpoint]/requests/[service_request_id].[format]
+PUT   http://[API endpoint]/requests/[service_request_id].[format]
+```
 
 Parameters:
 
@@ -212,14 +213,15 @@ Parameters:
 | address_string | * | String | Address for position |
 | photo_required | - | Boolean | Photo required |
 | media | - | String | Photo as Base64 encoded string |
-| detailed_status | - | String | Status (RECEIVED, IN_PROCESS, PROCESSED, REJECTED) |
+| detailed_status | - | String | CitySDK status |
 | status_notes | - | String | Status note |
 | priority | - | Integer | Priority |
 | delegation | - | String | Delegation to external role |
 | job_status | - | Integer | Job status |
 | job_priority | - | Integer | Job priority |
 
-*: Either `lat` and `long` or `address_string` are required
+*: Either `lat` and `long` or `address_string` are required\
+Available CitySDK states for this action: `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
 
 Sample Response:
 

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -14,14 +14,19 @@ To support some special functions there are also some additional enhancements to
 
 ### Get observable areas
 <code>http://[API endpoint]/areas.[format]</code>
+
 HTTP Method: GET
+
 Parameters:
+
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
 | area_code | - | Integer[] | IDs to filter districts |
 | with_districts | - | Boolean | return all existing districts, not available if using area_code |
+
 Sample Response:
+
 ```xml
 <areas>
 <area>
@@ -35,14 +40,19 @@ Sample Response:
 
 ### Get position coverage
 <code>http://[API endpoint]/coverage.[format]</code>
+
 HTTP Method: GET
+
 Parameters:
+
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
 | lat | X | Float | latitude value |
 | long | X | Float | longitude value |
+
 Sample Response:
+
 ```xml
 <hash>
 <result type="boolean">false</result>
@@ -51,18 +61,24 @@ Sample Response:
 
 ### Get discovery
 <code>http://[API endpoint]/discovery.[format]</code>
+
 HTTP Method: GET
 
 ### Get jobs list
 <code>http://[API endpoint]/jobs.[format]</code>
+
 HTTP Method: GET
+
 Parameters:
+
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
 | date | X | Date | Filter jobs that are the equal or lower than the given date |
 | status | - | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+
 Sample Response:
+
 ```xml
 <jobs>
 <job>
@@ -77,15 +93,20 @@ Sample Response:
 ```
 ### Create new job
 <code>http://[API endpoint]/jobs.[format]</code>
+
 HTTP Method: POST
+
 Parameters:
+
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
 | service_request_id | X | Integer | Affected issue ID |
 | agency_responsible | X | String | Name of team |
 | date | X | Date | Date for job |
+
 Sample Response:
+
 ```xml
 <jobs>
 <job>
@@ -99,15 +120,20 @@ Sample Response:
 ```
 ### Update job
 <code>http://[API endpoint]/jobs/[service_request_id].[format]</code>
+
 HTTP Method: PUT / PATCH
+
 Parameters:
+
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
 | service_request_id | X | Integer | Affected issue ID |
 | status | X | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
 | date | X | Date | Date of job |
+
 Sample Response:
+
 ```xml
 <jobs>
 <job>
@@ -122,8 +148,11 @@ Sample Response:
 
 ### Create new observation
 <code>http://[API endpoint]/observations.[format]</code>
+
 HTTP Method: POST
+
 Parameters:
+
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
@@ -135,8 +164,11 @@ Parameters:
 | ideas | - | Boolean | Include problems |
 | idea_service | | String | Filter ideas by main category IDs |
 | idea_service_sub | | String | Filter ideas by sub category IDs |
+
 *: Either geometry or area_code is required
+
 Sample Response:
+
 ```xml
 <observation>
 <rss-id>39a855f0a4924af3217a217c8dc78ece</rss-id>

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -13,9 +13,7 @@ To support some special functions there are also some additional enhancements to
 ## API methods
 
 ### Get observable areas
-<code>http://[API endpoint]/areas.[format]</code>
-
-HTTP Method: GET
+<code>GET http://[API endpoint]/areas.[format]</code>
 
 Parameters:
 
@@ -39,9 +37,7 @@ Sample Response:
 ```
 
 ### Get position coverage
-<code>http://[API endpoint]/coverage.[format]</code>
-
-HTTP Method: GET
+<code>GET http://[API endpoint]/coverage.[format]</code>
 
 Parameters:
 
@@ -60,14 +56,10 @@ Sample Response:
 ```
 
 ### Get discovery
-<code>http://[API endpoint]/discovery.[format]</code>
-
-HTTP Method: GET
+<code>GET http://[API endpoint]/discovery.[format]</code>
 
 ### Get jobs list
-<code>http://[API endpoint]/jobs.[format]</code>
-
-HTTP Method: GET
+<code>GET http://[API endpoint]/jobs.[format]</code>
 
 Parameters:
 
@@ -92,9 +84,7 @@ Sample Response:
 </jobs>
 ```
 ### Create new job
-<code>http://[API endpoint]/jobs.[format]</code>
-
-HTTP Method: POST
+<code>POST http://[API endpoint]/jobs.[format]</code>
 
 Parameters:
 
@@ -119,9 +109,8 @@ Sample Response:
 </jobs>
 ```
 ### Update job
-<code>http://[API endpoint]/jobs/[service_request_id].[format]</code>
-
-HTTP Method: PUT / PATCH
+<code>PATCH http://[API endpoint]/jobs/[service_request_id].[format]</code>
+<code>PUT   http://[API endpoint]/jobs/[service_request_id].[format]</code>
 
 Parameters:
 
@@ -147,16 +136,14 @@ Sample Response:
 ```
 
 ### Create new observation
-<code>http://[API endpoint]/observations.[format]</code>
-
-HTTP Method: POST
+<code>POST http://[API endpoint]/observations.[format]</code>
 
 Parameters:
 
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
-| geometry | * | String | WKT gemoemetry for observing area |
+| geometry | * | String | WKT geoemetry for observing area |
 | area_code | * | String | IDs of districts, -1 for instance |
 | problems | - | Boolean | Include problems |
 | problem_service | - | String | Filter problems by main category IDs |
@@ -175,9 +162,234 @@ Sample Response:
 </observatio>
 ```
 
-Einzelner Vorgang nach ID
-params:
-service_request_id  pflicht  - Vorgang-ID
-api_key             optional - API-Key
-extensions          optional - Response mit erweitereten Attributsausgaben
+### Get service requests list
+<code>GET http://[API endpoint]/requests.[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | - | String | API key |
+| service_request_id | - | Integer / String | List of multiple Request-IDs, comma delimited |
+| service_code | - | Integer | ID of category |
+| status | - | String | Filter issues by Open311 status, default = `open` |
+| detailed_status |  - | String | Filter issues by CitySDK status |
+| start_date | - | Date | Filter for issue date >= value, e.g 2011-01-01T00:00:00Z |
+| end_date | - | Date | Filter for isse date <= value, e.g 2011-01-01T00:00:00Z |
+| updated_after | - | Date | Filter for issue version >= value, e.g 2011-01-01T00:00:00Z |
+| updated_before | - | Date | Filter for issue version <= value, e.g 2011-01-01T00:00:00Z |
+| agency_responsible | - | String | Filter for issues by job team |
+| extensions | - | Boolean | Include extended attributs in response |
+| lat | - | Double | Filter restriction area (lat, long and radius required) |
+| long | - | Double | Filter restriction area (lat, long and radius required) |
+| radius | - | Double | Meter to filter restriction area (lat, long and radius required) |
+| keyword | - | String | Filter issues by kind, options: problem, idea, tip |
+| with_picture | - | Boolean | Filter issues with released photos |
+| also_archived | - | Boolean | Include already archived issues |
+| just_count | - | Boolean | Switch response to only return amount of affected issues |
+| max_requests | - | Integer | Maximum number of requests to return |
+| observation_key | - | String | MD5 hash of observed area to use as filter |
+| area_code | - | Integer | Filter issues by affected area ID |
+
+Available Open311 states: `open`, `closed`
+Available CitySDK states: `PENDING`, `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
+
+Sample Response:
+
+```xml
+<service_requests type="array">
+<request>
+<service_request_id>request.id</service_request_id>
+<status_notes/>
+<status>request.status</status>
+<service_code>request.service.code</service_code>
+<service_name>request.service.name</service_name>
+<description>request.description</description>
+<agency_responsible>request.agency_responsible</agency_responsible>
+<service_notice/>
+<requested_datetime>request.requested_datetime</requested_datetime>
+<updated_datetime>request.updated_datetime</updated_datetime>
+<expected_datetime/>
+<address>request.address</address>
+<adress_id/>
+<lat>request.position.lat</lat>
+<long>request.position.lat</long>
+<media_url/>
+<zipcode/>
+</request>
+</service_requests>
+```
+
+### Get service request
+<code>GET http://[API endpoint]/requests/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | - | String | API key |
+| service_request_id | X | Integer | Issue ID |
+| extensions | - | Boolean | Include extended attributes in response |
+
+Sample Response:
+
+```xml
+<service_requests type="array">
+<request>
+<service_request_id>request.id</service_request_id>
+<status_notes/>
+<status>request.status</status>
+<service_code>request.service.code</service_code>
+<service_name>request.service.name</service_name>
+<description>request.description</description>
+<agency_responsible>request.agency_responsible</agency_responsible>
+<service_notice/>
+<requested_datetime>request.requested_datetime</requested_datetime>
+<updated_datetime>request.updated_datetime</updated_datetime>
+<expected_datetime/>
+<address>request.address</address>
+<adress_id/>
+<lat>request.position.lat</lat>
+<long>request.position.lat</long>
+<media_url/>
+<zipcode/>
+<extended_attributes>
+<detailed_status>request.detailed_status</detailed_status>
+<media_urls>
+<media_url>request.media.url</media_url>
+</media_urls>
+<photo_required>request.photo_required</photo_required>
+<trust>request.trust</trust>
+<votes>request.votes</votes>
+</extended_attributes>
+</request>
+</service_requests>
+```
+### Create service request
+<code>POST http://[API endpoint]/requests.[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| email | X | String | Author email |
+| service_code | X | Integer | Category ID |
+| description | X | String | Description |
+| lat | * | Float | Latitude value of position |
+| long | * | Float | Longitude value of position |
+| address_string | * | String | Address for position |
+| photo_required | - | Boolean | Photo required |
+| media | - | String | Photo as Base64 encoded string |
+| privacy_policy_accepted | - | Boolean | Confirmation of accepted privacy policy |
+
+*: Either `lat` and `long` or `address_string` are required
+
+Sample Response:
+
+```xml
+<service_requests>
+<request>
+<service_request_id>request.id</service_request_id>
+</request>
+</service_requests>
+```
+### Update Service request
+<code>PATCH http://[API endpoint]/requests/[service_request_id].[format]</code>
+<code>PUT   http://[API endpoint]/requests/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| email | X | String | Author email |
+| service_code | X | Integer | Category ID |
+| description | - | String | Description |
+| lat | * | Float | Latitude value of position |
+| long | * | Float | Longitude value of position |
+| address_string | * | String | Address for position |
+| photo_required | - | Boolean | Photo required |
+| media | - | String | Photo as Base64 encoded string |
+| detailed_status | - | String | Status (RECEIVED, IN_PROCESS, PROCESSED, REJECTED) |
+| status_notes | - | String | Status note |
+| priority | - | Integer | Priority |
+| delegation | - | String | Delegation to external role |
+| job_status | - | Integer | Job status |
+| job_priority | - | Integer | Job priority |
+
+*: Either `lat` and `long` or `address_string` are required
+
+Sample Response:
+
+```xml
+<service_requests type="array">
+<request>
+<service_request_id>request.id</service_request_id>
+<status_notes/>
+<status>request.status</status>
+<service_code>request.service.code</service_code>
+<service_name>request.service.name</service_name>
+<description>request.description</description>
+<agency_responsible>request.agency_responsible</agency_responsible>
+<service_notice/>
+<requested_datetime>request.requested_datetime</requested_datetime>
+<updated_datetime>request.updated_datetime</updated_datetime>
+<expected_datetime/>
+<address>request.address</address>
+<adress_id/>
+<lat>request.position.lat</lat>
+<long>request.position.lat</long>
+<media_url/>
+<zipcode/>
+</request>
+</service_requests>
+```
+
+### GET services list
+<code>GET http://[API endpoint]/services.[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | - | String | API key |
+
+Sample Response:
+
+```xml
+<services type="array">
+<service>
+<service_code>category.id</service_code>
+<service_name>category.name</service_name>
+<description/>
+<metadata>false</metadata>
+<type>realtime</type>
+<keywords>category.parent.typ [problem|idee|tipp]</keywords>
+<group>category.parent.name</group>
+</service>
+</services>
+```
+### Get service definition
+<code>GET http://[API endpoint]/services/[id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | - | String | API key |
+| id | X | Integer | ID of service|
+
+Sample Response:
+
+```xml
+<service_definition type="array">
+<service>
+<service_code>category.id</service_code>
+<service_name>category.name</service_name>
+<keywords>category.parent.typ [problem|idee|tipp]</keywords>
+<group>category.parent.name</group>
+</service>
+</service_definition>
+```
 

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -1,0 +1,151 @@
+# Klarschiff-CitySDK
+Implementation of CitySDK-Smart-Participation-API for Klarschiff
+
+## Supported formats and encoding
+The API supports both JSON and XML. All strings are encoded with UTF-8.
+
+## General info
+The Issue Reporting API is based on GeoReport API version 2, better known as the [Open311 specification](http://open311.org/).
+The interface is designed in such a way that any GeoReport v2 compatible client is able to use the interface.
+This interface is compliant with [CitySDK](http://www.citysdk.eu/) specific enhancements to Open311.
+To support some special functions there are also some additional enhancements to Open311 and CitySDK.
+
+## API methods
+
+### Get observable areas
+<code>http://[API endpoint]/areas.[format]</code>
+HTTP Method: GET
+Parameters:
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| area_code | - | Integer[] | IDs to filter districts |
+| with_districts | - | Boolean | return all existing districts, not available if using area_code |
+Sample Response:
+```xml
+<areas>
+<area>
+<id>30</id>
+<name>Biestow</name>
+<grenze>MULTIPOLYGON (((...)))</grenze>
+</area>
+...
+</areas>
+```
+
+### Get position coverage
+<code>http://[API endpoint]/coverage.[format]</code>
+HTTP Method: GET
+Parameters:
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| lat | X | Float | latitude value |
+| long | X | Float | longitude value |
+Sample Response:
+```xml
+<hash>
+<result type="boolean">false</result>
+</hash>
+```
+
+### Get discovery
+<code>http://[API endpoint]/discovery.[format]</code>
+HTTP Method: GET
+
+### Get jobs list
+<code>http://[API endpoint]/jobs.[format]</code>
+HTTP Method: GET
+Parameters:
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| date | X | Date | Filter jobs that are the equal or lower than the given date |
+| status | - | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+Sample Response:
+```xml
+<jobs>
+<job>
+<id>job.id</id>
+<service-request-id>job.service_request_id</service-request-id>
+<date>job.date</date>
+<agency-responsible>job.agency_responsible</agency-responsible>
+<status>job.status</status>
+</job>
+...
+</jobs>
+```
+### Create new job
+<code>http://[API endpoint]/jobs.[format]</code>
+HTTP Method: POST
+Parameters:
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| service_request_id | X | Integer | Affected issue ID |
+| agency_responsible | X | String | Name of team |
+| date | X | Date | Date for job |
+Sample Response:
+```xml
+<jobs>
+<job>
+<id>job.id</id>
+<service-request-id>job.service_request_id</service-request-id>
+<date>job.date</date>
+<agency-responsible>job.agency_responsible</agency-responsible>
+<status>job.status</status>
+</job>
+</jobs>
+```
+### Update job
+<code>http://[API endpoint]/jobs/[service_request_id].[format]</code>
+HTTP Method: PUT / PATCH
+Parameters:
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| service_request_id | X | Integer | Affected issue ID |
+| status | X | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+| date | X | Date | Date of job |
+Sample Response:
+```xml
+<jobs>
+<job>
+<id>job.id</id>
+<service-request-id>job.service_request_id</service-request-id>
+<date>job.date</date>
+<agency-responsible>job.agency_responsible</agency-responsible>
+<status>job.status</status>
+</job>
+</jobs>
+```
+
+### Create new observation
+<code>http://[API endpoint]/observations.[format]</code>
+HTTP Method: POST
+Parameters:
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| api_key | X | String | API key |
+| geometry | * | String | WKT gemoemetry for observing area |
+| area_code | * | String | IDs of districts, -1 for instance |
+| problems | - | Boolean | Include problems |
+| problem_service | - | String | Filter problems by main category IDs |
+| problem_service_sub | - | String | Filter problems by sub category IDs |
+| ideas | - | Boolean | Include problems |
+| idea_service | | String | Filter ideas by main category IDs |
+| idea_service_sub | | String | Filter ideas by sub category IDs |
+*: Either geometry or area_code is required
+Sample Response:
+```xml
+<observation>
+<rss-id>39a855f0a4924af3217a217c8dc78ece</rss-id>
+</observatio>
+```
+
+Einzelner Vorgang nach ID
+params:
+service_request_id  pflicht  - Vorgang-ID
+api_key             optional - API-Key
+extensions          optional - Response mit erweitereten Attributsausgaben
+

--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -254,7 +254,7 @@ Parameters:
 | Name | Required | Type | Notes |
 |:--|:-:|:--|:--|
 | api_key | X | String | API key |
-| area_code | - | Integer[] | IDs to filter districts |
+| area_code | - | Integer / String | ID to filter districts, separated by comma for multiple values |
 | with_districts | - | Boolean | return all existing districts, not available if using area_code |
 
 Sample Response:
@@ -391,5 +391,172 @@ Sample Response:
 <observation>
   <rss-id>39a855f0a4924af3217a217c8dc78ece</rss-id>
 </observatio>
+```
+
+### Create new abuse for service request
+<code>POST http://[API endpoint]/requests/abuses/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| service_request_id | X | Integer | Issue ID |
+| author | X | String | Author email |
+| comment | X | String | |
+| privacy_policy_accepted | - | Boolean | Confirmation of accepted privacy policy |
+
+Sample Response:
+
+```xml
+<abuses>
+  <abuse>
+    <id>abuse.id</id>
+  </abuse>
+</abuses>
+```
+
+### Get comments list for service request
+<code>GET http://[API endpoint]/requests/comments/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| service_request_id | X | Integer | Issue ID |
+| api_key | X | String | API key |
+
+Sample Response:
+
+```xml
+<comments type="array">
+  <comment>
+    <id>comment.id</id>
+    <jurisdiction_id></jurisdiction_id>
+    <comment>comment.text</comment>
+    <datetime>comment.datetime</datetime>
+    <service_request_id>comment.service_request_id</service_request_id>
+  </comment>
+</comments>
+```
+### Create new comment for service request
+<code>POST http://[API endpoint]/requests/comments/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| service_request_id | X | Integer | Issue ID |
+| api_key | X | String | API key |
+| author | X | String | Author email |
+| comment | X | String | |
+| privacy_policy_accepted | - | Boolean | Confirmation of accepted privacy policy |
+
+Sample Response:
+
+```xml
+<comments>
+  <comment>
+    <id>comment.id</id>
+    <jurisdiction_id></jurisdiction_id>
+    <comment>comment.text</comment>
+    <datetime>comment.datetime</datetime>
+    <service_request_id>comment.service_request_id</service_request_id>
+  </comment>
+</comments>
+```
+
+### Get notes list for service request
+<code>GET http://[API endpoint]/requests/notes/[service_request_id].[format]</code>
+
+Notes are internal comments on issues.
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| service_request_id | X | Integer | Issue ID |
+| api_key | X | String | API key |
+
+Sample Response:
+
+```xml
+<notes type="array">
+  <note>
+    <jurisdiction_id></jurisdiction_id>
+    <comment>note.text</comment>
+    <datetime>note.datetime</datetime>
+    <service_request_id>note.service_request_id</service_request_id>
+    <author>note.author</author>
+  </note>
+</notes>
+```
+### Create new note for service request
+<code>POST http://[API endpoint]/requests/notes/[service_request_id].[format]</code>
+
+Notes are internal comments on issues.
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| service_request_id | X | Integer | Issue ID |
+| api_key | X | String | API key |
+| author | X | String | Author email |
+| note | X | String | Internal comment for issue |
+
+Sample Response:
+
+```xml
+<notes>
+  <note>
+    <jurisdiction_id></jurisdiction_id>
+    <comment>note.text</comment>
+    <datetime>note.datetime</datetime>
+    <service_request_id>note.service_request_id</service_request_id>
+    <author>note.author</author>
+  </note>
+</notes>
+```
+
+### Create new photo for service request
+<code>POST http://[API endpoint]/requests/photos/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| service_request_id | X | Integer | Issue ID |
+| author | X | String | Author email |
+| media | X | String | Photo as Base64 encoded string |
+
+Sample Response:
+
+```xml
+<photos>
+  <photo>
+    <id>photo.id</id>
+  </photo>
+</photos>
+```
+
+### Create new vote for service request
+<code>POST http://[API endpoint]/requests/votes/[service_request_id].[format]</code>
+
+Parameters:
+
+| Name | Required | Type | Notes |
+|:--|:-:|:--|:--|
+| service_request_id | X | Integer | Issue ID |
+| author | X | String | Author email |
+| privacy_policy_accepted | - | Boolean | Confirmation of accepted privacy policy |
+
+Sample Response:
+
+```xml
+<votes>
+  <vote>
+    <id>vote.id</id>
+  </vote>
+</votes>
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![License](https://img.shields.io/github/license/bfpi/klarschiff-backoffice)](LICENSE)
 
 # Klarschiff-Backoffice
-
+## CitySDK API
+Die Anwendung stellt eine [CitySDK API](CitySDK_API.md) inkl. zusätzlicher Erweiterungen bereit.
 ## Installation
 ### Voraussetzungen
 - RVM / oder andere Rubyversionsverwaltung

--- a/app/controllers/citysdk/areas_controller.rb
+++ b/app/controllers/citysdk/areas_controller.rb
@@ -20,17 +20,15 @@ module Citysdk
     # :apidoc: ```xml
     # :apidoc: <areas>
     # :apidoc:   <area>
-    # :apidoc:   <id>30</id>
-    # :apidoc:   <name>Biestow</name>
-    # :apidoc:   <grenze>MULTIPOLYGON (((...)))</grenze>
+    # :apidoc:     <id>30</id>
+    # :apidoc:     <name>Biestow</name>
+    # :apidoc:     <grenze>MULTIPOLYGON (((...)))</grenze>
     # :apidoc:   </area>
     # :apidoc:   ...
     # :apidoc: </areas>
     # :apidoc: ```
     def index
-      @response = limit_response(order_response(search_areas))
-      citysdk_response(@response,
-                       { root: :areas, element_name: :area })
+      citysdk_response limit_response(order_response(search_areas)), { root: :areas, element_name: :area }
     end
 
     private

--- a/app/controllers/citysdk/areas_controller.rb
+++ b/app/controllers/citysdk/areas_controller.rb
@@ -10,7 +10,7 @@ module Citysdk
     # :apidoc: | Name | Required | Type | Notes |
     # :apidoc: |:--|:-:|:--|:--|
     # :apidoc: | api_key | X | String | API key |
-    # :apidoc: | area_code | - | Integer[] | IDs to filter districts |
+    # :apidoc: | area_code | - | Integer / String | ID to filter districts, separated by comma for multiple values |
     # :apidoc: | with_districts | - | Boolean | return all existing districts, not available if using area_code |
     # :apidoc:
     # :apidoc: Sample Response:

--- a/app/controllers/citysdk/areas_controller.rb
+++ b/app/controllers/citysdk/areas_controller.rb
@@ -3,9 +3,7 @@
 module Citysdk
   class AreasController < CitysdkController
     # :apidoc: ### Get observable areas
-    # :apidoc: <code>http://[API endpoint]/areas.[format]</code>
-    # :apidoc:
-    # :apidoc: HTTP Method: GET
+    # :apidoc: <code>GET http://[API endpoint]/areas.[format]</code>
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:

--- a/app/controllers/citysdk/areas_controller.rb
+++ b/app/controllers/citysdk/areas_controller.rb
@@ -2,15 +2,35 @@
 
 module Citysdk
   class AreasController < CitysdkController
-    # Liste von Gebietsgrenzen
-    # params:
-    #   api_key         optional - API-Key
-    #   area_code       optional - IDs der selektierten Stadtteile
-    #   with_districts  optional - Response mit allen verfuegbaren Stadtteilgrenzen
+    # :apidoc: ### Get observable areas
+    # :apidoc: <code>http://[API endpoint]/areas.[format]</code>
+    # :apidoc:
+    # :apidoc: HTTP Method: GET
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | X | String | API key |
+    # :apidoc: | area_code | - | Integer[] | IDs to filter districts |
+    # :apidoc: | with_districts | - | Boolean | return all existing districts, not available if using area_code |
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <areas>
+    # :apidoc:   <area>
+    # :apidoc:   <id>30</id>
+    # :apidoc:   <name>Biestow</name>
+    # :apidoc:   <grenze>MULTIPOLYGON (((...)))</grenze>
+    # :apidoc:   </area>
+    # :apidoc:   ...
+    # :apidoc: </areas>
+    # :apidoc: ```
     def index
       @response = limit_response(order_response(search_areas))
       citysdk_response(@response,
-        { root: :areas, element_name: :area })
+                       { root: :areas, element_name: :area })
     end
 
     private

--- a/app/controllers/citysdk/coverage_controller.rb
+++ b/app/controllers/citysdk/coverage_controller.rb
@@ -2,9 +2,31 @@
 
 module Citysdk
   class CoverageController < CitysdkController
+    # :apidoc: ### Get position coverage
+    # :apidoc: <code>http://[API endpoint]/coverage.[format]</code>
+    # :apidoc:
+    # :apidoc: HTTP Method: GET
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | X | String | API key |
+    # :apidoc: | lat | X | Float | latitude value |
+    # :apidoc: | long | X | Float | longitude value |
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <hash>
+    # :apidoc:   <result type="boolean">false</result>
+    # :apidoc: </hash>
+    # :apidoc: ```
     def valid
-      citysdk_response(response_data)
+      citysdk_response response_data
     end
+
+    private
 
     def response_data
       if instances.blank? || (instance_url = instances.filter_map do |fm|

--- a/app/controllers/citysdk/coverage_controller.rb
+++ b/app/controllers/citysdk/coverage_controller.rb
@@ -3,9 +3,7 @@
 module Citysdk
   class CoverageController < CitysdkController
     # :apidoc: ### Get position coverage
-    # :apidoc: <code>http://[API endpoint]/coverage.[format]</code>
-    # :apidoc:
-    # :apidoc: HTTP Method: GET
+    # :apidoc: <code>GET http://[API endpoint]/coverage.[format]</code>
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:

--- a/app/controllers/citysdk/discovery_controller.rb
+++ b/app/controllers/citysdk/discovery_controller.rb
@@ -2,6 +2,10 @@
 
 module Citysdk
   class DiscoveryController < CitysdkController
+    # :apidoc: ### Get discovery
+    # :apidoc: <code>http://[API endpoint]/discovery.[format]</code>
+    # :apidoc:
+    # :apidoc: HTTP Method: GET
     def index
       citysdk_response(Citysdk::Discovery.new, { element_name: :discovery })
     end

--- a/app/controllers/citysdk/discovery_controller.rb
+++ b/app/controllers/citysdk/discovery_controller.rb
@@ -3,9 +3,7 @@
 module Citysdk
   class DiscoveryController < CitysdkController
     # :apidoc: ### Get discovery
-    # :apidoc: <code>http://[API endpoint]/discovery.[format]</code>
-    # :apidoc:
-    # :apidoc: HTTP Method: GET
+    # :apidoc: <code>GET http://[API endpoint]/discovery.[format]</code>
     def index
       citysdk_response(Citysdk::Discovery.new, { element_name: :discovery })
     end

--- a/app/controllers/citysdk/jobs_controller.rb
+++ b/app/controllers/citysdk/jobs_controller.rb
@@ -4,23 +4,66 @@ module Citysdk
   class JobsController < CitysdkController
     skip_before_action :validate_status
 
-    # Neuen Auftrag anlegen
-    # params:
-    #   api_key             pflicht - API-Key
-    #   date                pflicht - Datum
-    #   status              optional - Status
+    # :apidoc: ### Get jobs list
+    # :apidoc: <code>http://[API endpoint]/jobs.[format]</code>
+    # :apidoc:
+    # :apidoc: HTTP Method: GET
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | X | String | API key |
+    # :apidoc: | date | X | Date | Filter jobs that are the equal or lower than the given date |
+    # :apidoc: | status | - | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <jobs>
+    # :apidoc:   <job>
+    # :apidoc:     <id>job.id</id>
+    # :apidoc:     <service-request-id>job.service_request_id</service-request-id>
+    # :apidoc:     <date>job.date</date>
+    # :apidoc:     <agency-responsible>job.agency_responsible</agency-responsible>
+    # :apidoc:     <status>job.status</status>
+    # :apidoc:   </job>
+    # :apidoc:   ...
+    # :apidoc: </jobs>
+    # :apidoc: ```
     def index
       return citysdk_respond_with_unprocessable_entity(t(:date_missing)) if params[:date].blank?
 
       citysdk_response(jobs, root: :jobs, element_name: :job)
     end
 
-    # Neuen Auftrag anlegen
-    # params:
-    #   api_key             pflicht - API-Key
-    #   service_request_id  pflicht - Vorgang-ID
-    #   agency_responsible  pflicht - Aussendienst-Team
-    #   date                pflicht - Datum
+    # :apidoc: ### Create new job
+    # :apidoc: <code>http://[API endpoint]/jobs.[format]</code>
+    # :apidoc:
+    # :apidoc: HTTP Method: POST
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | X | String | API key |
+    # :apidoc: | service_request_id | X | Integer | Affected issue ID |
+    # :apidoc: | agency_responsible | X | String | Name of team |
+    # :apidoc: | date | X | Date | Date for job |
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <jobs>
+    # :apidoc:   <job>
+    # :apidoc:     <id>job.id</id>
+    # :apidoc:     <service-request-id>job.service_request_id</service-request-id>
+    # :apidoc:     <date>job.date</date>
+    # :apidoc:     <agency-responsible>job.agency_responsible</agency-responsible>
+    # :apidoc:     <status>job.status</status>
+    # :apidoc:   </job>
+    # :apidoc: </jobs>
+    # :apidoc: ```
     def create
       job = Citysdk::Job.new
       job.status = :unchecked
@@ -35,12 +78,33 @@ module Citysdk
       citysdk_response issue.job.becomes(Citysdk::Job), root: :jobs, element_name: :job, status: :created
     end
 
-    # Auftrag aktualisieren
-    # params:
-    #   api_key             pflicht - API-Key
-    #   service_request_id  pflicht - Vorgang-ID
-    #   status              pflicht - Status (CHECKED, UNCHECKED, NOT_CHECKABLE)
-    #   date                pflicht - Datum
+    # :apidoc: ### Update job
+    # :apidoc: <code>http://[API endpoint]/jobs/[service_request_id].[format]</code>
+    # :apidoc:
+    # :apidoc: HTTP Method: PUT / PATCH
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | X | String | API key |
+    # :apidoc: | service_request_id | X | Integer | Affected issue ID |
+    # :apidoc: | status | X | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+    # :apidoc: | date | X | Date | Date of job |
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <jobs>
+    # :apidoc:   <job>
+    # :apidoc:     <id>job.id</id>
+    # :apidoc:     <service-request-id>job.service_request_id</service-request-id>
+    # :apidoc:     <date>job.date</date>
+    # :apidoc:     <agency-responsible>job.agency_responsible</agency-responsible>
+    # :apidoc:     <status>job.status</status>
+    # :apidoc:   </job>
+    # :apidoc: </jobs>
+    # :apidoc: ```
     def update
       issue = Issue.find(params[:id])
       raise ActiveRecord::RecordNotFound unless issue.job

--- a/app/controllers/citysdk/jobs_controller.rb
+++ b/app/controllers/citysdk/jobs_controller.rb
@@ -13,7 +13,9 @@ module Citysdk
     # :apidoc: |:--|:-:|:--|:--|
     # :apidoc: | api_key | X | String | API key |
     # :apidoc: | date | X | Date | Filter jobs that are the equal or lower than the given date |
-    # :apidoc: | status | - | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+    # :apidoc: | status | - | String | Job status |
+    # :apidoc:
+    # :apidoc: Available job states for this action: `CHECKED`, `UNCHECKED`, `NOT_CHECKABLE`
     # :apidoc:
     # :apidoc: Sample Response:
     # :apidoc:
@@ -75,8 +77,10 @@ module Citysdk
     end
 
     # :apidoc: ### Update job
-    # :apidoc: <code>PATCH http://[API endpoint]/jobs/[service_request_id].[format]</code>
-    # :apidoc: <code>PUT   http://[API endpoint]/jobs/[service_request_id].[format]</code>
+    # :apidoc: ```
+    # :apidoc: PATCH http://[API endpoint]/jobs/[service_request_id].[format]
+    # :apidoc: PUT   http://[API endpoint]/jobs/[service_request_id].[format]
+    # :apidoc: ```
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:
@@ -84,8 +88,10 @@ module Citysdk
     # :apidoc: |:--|:-:|:--|:--|
     # :apidoc: | api_key | X | String | API key |
     # :apidoc: | service_request_id | X | Integer | Affected issue ID |
-    # :apidoc: | status | X | String | Status (CHECKED, UNCHECKED, NOT_CHECKABLE) |
+    # :apidoc: | status | X | String | Job status |
     # :apidoc: | date | X | Date | Date of job |
+    # :apidoc:
+    # :apidoc: Available job states for this action: `CHECKED`, `UNCHECKED`, `NOT_CHECKABLE`
     # :apidoc:
     # :apidoc: Sample Response:
     # :apidoc:

--- a/app/controllers/citysdk/jobs_controller.rb
+++ b/app/controllers/citysdk/jobs_controller.rb
@@ -5,9 +5,7 @@ module Citysdk
     skip_before_action :validate_status
 
     # :apidoc: ### Get jobs list
-    # :apidoc: <code>http://[API endpoint]/jobs.[format]</code>
-    # :apidoc:
-    # :apidoc: HTTP Method: GET
+    # :apidoc: <code>GET http://[API endpoint]/jobs.[format]</code>
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:
@@ -38,9 +36,7 @@ module Citysdk
     end
 
     # :apidoc: ### Create new job
-    # :apidoc: <code>http://[API endpoint]/jobs.[format]</code>
-    # :apidoc:
-    # :apidoc: HTTP Method: POST
+    # :apidoc: <code>POST http://[API endpoint]/jobs.[format]</code>
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:
@@ -79,9 +75,8 @@ module Citysdk
     end
 
     # :apidoc: ### Update job
-    # :apidoc: <code>http://[API endpoint]/jobs/[service_request_id].[format]</code>
-    # :apidoc:
-    # :apidoc: HTTP Method: PUT / PATCH
+    # :apidoc: <code>PATCH http://[API endpoint]/jobs/[service_request_id].[format]</code>
+    # :apidoc: <code>PUT   http://[API endpoint]/jobs/[service_request_id].[format]</code>
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:

--- a/app/controllers/citysdk/observations_controller.rb
+++ b/app/controllers/citysdk/observations_controller.rb
@@ -2,20 +2,38 @@
 
 module Citysdk
   class ObservationsController < CitysdkController
-    # Neue Beobachtungsflaeche anlegen
-    # params:
-    #   area_code             optional - IDs der Stadtteilgrenze (-1 fuer Stadtgrenze)
-    #   geometry              optional - Geometrie einer erstellten Flaeche als WKT
-    #   problems              optional - Probleme ueberwachen
-    #   problem_service       optional - IDs ausgewaehlter Hauptkategorien fuer Probleme
-    #   problem_service_sub   optional - IDs ausgewaehlter Unterkategorien fuer Probleme
-    #   ideas                 optional - Ideen ueberwachen
-    #   idea_service          optional - IDs ausgwaehlte Hauptkategorien fuer Ideen
-    #   idea_service_sub      optional - IDs ausgwaehlte Unterkategorien fuer Ideen
+    # :apidoc: ### Create new observation
+    # :apidoc: <code>http://[API endpoint]/observations.[format]</code>
+    # :apidoc:
+    # :apidoc: HTTP Method: POST
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | X | String | API key |
+    # :apidoc: | geometry | * | String | WKT gemoemetry for observing area |
+    # :apidoc: | area_code | * | String | IDs of districts, -1 for instance |
+    # :apidoc: | problems | - | Boolean | Include problems |
+    # :apidoc: | problem_service | - | String | Filter problems by main category IDs |
+    # :apidoc: | problem_service_sub | - | String | Filter problems by sub category IDs |
+    # :apidoc: | ideas | - | Boolean | Include problems |
+    # :apidoc: | idea_service | | String | Filter ideas by main category IDs |
+    # :apidoc: | idea_service_sub | | String | Filter ideas by sub category IDs |
+    # :apidoc:
+    # :apidoc: *: Either geometry or area_code is required
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <observation>
+    # :apidoc:   <rss-id>39a855f0a4924af3217a217c8dc78ece</rss-id>
+    # :apidoc: </observatio>
+    # :apidoc: ```
     def create
       observation = Citysdk::Observation.new
       observation.assign_attributes(params.permit(:area_code, :geometry, :problems, :problem_service,
-        :problem_service_sub, :ideas, :idea_service, :idea_service_sub))
+                                                  :problem_service_sub, :ideas, :idea_service, :idea_service_sub))
 
       obs = observation.becomes(::Observation)
       obs.save!

--- a/app/controllers/citysdk/observations_controller.rb
+++ b/app/controllers/citysdk/observations_controller.rb
@@ -3,16 +3,14 @@
 module Citysdk
   class ObservationsController < CitysdkController
     # :apidoc: ### Create new observation
-    # :apidoc: <code>http://[API endpoint]/observations.[format]</code>
-    # :apidoc:
-    # :apidoc: HTTP Method: POST
+    # :apidoc: <code>POST http://[API endpoint]/observations.[format]</code>
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:
     # :apidoc: | Name | Required | Type | Notes |
     # :apidoc: |:--|:-:|:--|:--|
     # :apidoc: | api_key | X | String | API key |
-    # :apidoc: | geometry | * | String | WKT gemoemetry for observing area |
+    # :apidoc: | geometry | * | String | WKT geoemetry for observing area |
     # :apidoc: | area_code | * | String | IDs of districts, -1 for instance |
     # :apidoc: | problems | - | Boolean | Include problems |
     # :apidoc: | problem_service | - | String | Filter problems by main category IDs |

--- a/app/controllers/citysdk/observations_controller.rb
+++ b/app/controllers/citysdk/observations_controller.rb
@@ -19,7 +19,7 @@ module Citysdk
     # :apidoc: | idea_service | | String | Filter ideas by main category IDs |
     # :apidoc: | idea_service_sub | | String | Filter ideas by sub category IDs |
     # :apidoc:
-    # :apidoc: *: Either geometry or area_code is required
+    # :apidoc: *: Either `geometry` or `area_code` is required
     # :apidoc:
     # :apidoc: Sample Response:
     # :apidoc:

--- a/app/controllers/citysdk/observations_controller.rb
+++ b/app/controllers/citysdk/observations_controller.rb
@@ -33,7 +33,7 @@ module Citysdk
     def create
       observation = Citysdk::Observation.new
       observation.assign_attributes(params.permit(:area_code, :geometry, :problems, :problem_service,
-                                                  :problem_service_sub, :ideas, :idea_service, :idea_service_sub))
+        :problem_service_sub, :ideas, :idea_service, :idea_service_sub))
 
       obs = observation.becomes(::Observation)
       obs.save!

--- a/app/controllers/citysdk/requests/abuses_controller.rb
+++ b/app/controllers/citysdk/requests/abuses_controller.rb
@@ -3,12 +3,27 @@
 module Citysdk
   module Requests
     class AbusesController < CitysdkController
-      # Missbrauch melden
-      # params:
-      #   service_request_id        pflicht   - Vorgang-ID
-      #   author                    pflicht   - Autor-Email
-      #   comment                   pflicht   - Kommentar
-      #   privacy_policy_accepted   optional  - Bestaetigung Datenschutz
+      # :apidoc: ### Create new abuse for service request
+      # :apidoc: <code>POST http://[API endpoint]/requests/abuses/[service_request_id].[format]</code>
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | service_request_id | X | Integer | Issue ID |
+      # :apidoc: | author | X | String | Author email |
+      # :apidoc: | comment | X | String | |
+      # :apidoc: | privacy_policy_accepted | - | Boolean | Confirmation of accepted privacy policy |
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <abuses>
+      # :apidoc:   <abuse>
+      # :apidoc:     <id>abuse.id</id>
+      # :apidoc:   </abuse>
+      # :apidoc: </abuses>
+      # :apidoc: ```
       def create
         abuse = Citysdk::Abuse.new
         abuse.assign_attributes(params.permit(:service_request_id, :author, :comment, :privacy_policy_accepted))

--- a/app/controllers/citysdk/requests/comments_controller.rb
+++ b/app/controllers/citysdk/requests/comments_controller.rb
@@ -3,21 +3,60 @@
 module Citysdk
   module Requests
     class CommentsController < CitysdkController
-      # Lob/Hinweis/Kritik
-      #   service_request_id  pflicht  - Vorgang-ID
-      #   api_key             pflicht  - API-Key
+      # :apidoc: ### Get comments list for service request
+      # :apidoc: <code>GET http://[API endpoint]/requests/comments/[service_request_id].[format]</code>
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | service_request_id | X | Integer | Issue ID |
+      # :apidoc: | api_key | X | String | API key |
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <comments type="array">
+      # :apidoc:   <comment>
+      # :apidoc:     <id>comment.id</id>
+      # :apidoc:     <jurisdiction_id></jurisdiction_id>
+      # :apidoc:     <comment>comment.text</comment>
+      # :apidoc:     <datetime>comment.datetime</datetime>
+      # :apidoc:     <service_request_id>comment.service_request_id</service_request_id>
+      # :apidoc:   </comment>
+      # :apidoc: </comments>
+      # :apidoc: ```
       def index
         comments = Citysdk::Comment.where(issue_id: params[:service_request_id])
         citysdk_response comments, root: :comments, element_name: :comment
       end
 
-      # Lob/Hinweis/Kritik anlegen
-      # params:
-      #   service_request_id        pflicht  - Vorgang-ID
-      #   api_key                   pflicht  - API-Key
-      #   author                    pflicht  - Autor-Email
-      #   comment                   pflicht  - Kommentar
-      #   privacy_policy_accepted   optional - Bestaetigung Datenschutz
+      # :apidoc: ### Create new comment for service request
+      # :apidoc: <code>POST http://[API endpoint]/requests/comments/[service_request_id].[format]</code>
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | service_request_id | X | Integer | Issue ID |
+      # :apidoc: | api_key | X | String | API key |
+      # :apidoc: | author | X | String | Author email |
+      # :apidoc: | comment | X | String | |
+      # :apidoc: | privacy_policy_accepted | - | Boolean | Confirmation of accepted privacy policy |
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <comments>
+      # :apidoc:   <comment>
+      # :apidoc:     <id>comment.id</id>
+      # :apidoc:     <jurisdiction_id></jurisdiction_id>
+      # :apidoc:     <comment>comment.text</comment>
+      # :apidoc:     <datetime>comment.datetime</datetime>
+      # :apidoc:     <service_request_id>comment.service_request_id</service_request_id>
+      # :apidoc:   </comment>
+      # :apidoc: </comments>
+      # :apidoc: ```
       def create
         comment = Citysdk::Comment.new
         comment.assign_attributes(params.permit(:service_request_id, :author, :comment, :privacy_policy_accepted))

--- a/app/controllers/citysdk/requests/notes_controller.rb
+++ b/app/controllers/citysdk/requests/notes_controller.rb
@@ -3,20 +3,63 @@
 module Citysdk
   module Requests
     class NotesController < CitysdkController
-      # interne Kommentare
-      #   service_request_id  pflicht  - Vorgang-ID
-      #   api_key             pflicht  - API-Key
+      # :apidoc: ### Get notes list for service request
+      # :apidoc: <code>GET http://[API endpoint]/requests/notes/[service_request_id].[format]</code>
+      # :apidoc:
+      # :apidoc: Notes are internal comments on issues.
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | service_request_id | X | Integer | Issue ID |
+      # :apidoc: | api_key | X | String | API key |
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <notes type="array">
+      # :apidoc:   <note>
+      # :apidoc:     <jurisdiction_id></jurisdiction_id>
+      # :apidoc:     <comment>note.text</comment>
+      # :apidoc:     <datetime>note.datetime</datetime>
+      # :apidoc:     <service_request_id>note.service_request_id</service_request_id>
+      # :apidoc:     <author>note.author</author>
+      # :apidoc:   </note>
+      # :apidoc: </notes>
+      # :apidoc: ```
       def index
         notes = Citysdk::Note.where(issue_id: params[:service_request_id])
         citysdk_response notes, root: :notes, element_name: :note
       end
 
-      # internen Kommentar anlegen
-      # params:
-      #   service_request_id  pflicht  - Vorgang-ID
-      #   api_key             pflicht  - API-Key
-      #   author              pflicht  - Autor-Email
-      #   note             pflicht  - Kommentar
+      # :apidoc: ### Create new note for service request
+      # :apidoc: <code>POST http://[API endpoint]/requests/notes/[service_request_id].[format]</code>
+      # :apidoc:
+      # :apidoc: Notes are internal comments on issues.
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | service_request_id | X | Integer | Issue ID |
+      # :apidoc: | api_key | X | String | API key |
+      # :apidoc: | author | X | String | Author email |
+      # :apidoc: | note | X | String | Internal comment for issue |
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <notes>
+      # :apidoc:   <note>
+      # :apidoc:     <jurisdiction_id></jurisdiction_id>
+      # :apidoc:     <comment>note.text</comment>
+      # :apidoc:     <datetime>note.datetime</datetime>
+      # :apidoc:     <service_request_id>note.service_request_id</service_request_id>
+      # :apidoc:     <author>note.author</author>
+      # :apidoc:   </note>
+      # :apidoc: </notes>
+      # :apidoc: ```
       def create
         note = Citysdk::Note.new
         note.assign_attributes(params.permit(:service_request_id, :author, :comment, :privacy_policy_accepted))

--- a/app/controllers/citysdk/requests/photos_controller.rb
+++ b/app/controllers/citysdk/requests/photos_controller.rb
@@ -3,11 +3,26 @@
 module Citysdk
   module Requests
     class PhotosController < CitysdkController
-      # Foto zur Meldung hinzufuegen
-      # params:
-      #   service_request_id        pflicht   - Vorgang-ID
-      #   author                    pflicht   - Autor-Email
-      #   media                     pflicht   - Foto (Base64)
+      # :apidoc: ### Create new photo for service request
+      # :apidoc: <code>POST http://[API endpoint]/requests/photos/[service_request_id].[format]</code>
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | service_request_id | X | Integer | Issue ID |
+      # :apidoc: | author | X | String | Author email |
+      # :apidoc: | media | X | String | Photo as Base64 encoded string |
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <photos>
+      # :apidoc:   <photo>
+      # :apidoc:     <id>photo.id</id>
+      # :apidoc:   </photo>
+      # :apidoc: </photos>
+      # :apidoc: ```
       def create
         photo = Citysdk::Photo.new
         photo.assign_attributes(params.permit(:service_request_id, :author, :media))

--- a/app/controllers/citysdk/requests/votes_controller.rb
+++ b/app/controllers/citysdk/requests/votes_controller.rb
@@ -3,11 +3,26 @@
 module Citysdk
   module Requests
     class VotesController < CitysdkController
-      # Unterstuetzung melden
-      # params:
-      #   service_request_id        pflicht   - Vorgang-ID
-      #   author                    pflicht   - Autor-Email
-      #   privacy_policy_accepted   optional  - Bestaetigung Datenschutz
+      # :apidoc: ### Create new vote for service request
+      # :apidoc: <code>POST http://[API endpoint]/requests/votes/[service_request_id].[format]</code>
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | service_request_id | X | Integer | Issue ID |
+      # :apidoc: | author | X | String | Author email |
+      # :apidoc: | privacy_policy_accepted | - | Boolean | Confirmation of accepted privacy policy |
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <votes>
+      # :apidoc:   <vote>
+      # :apidoc:     <id>vote.id</id>
+      # :apidoc:   </vote>
+      # :apidoc: </votes>
+      # :apidoc: ```
       def create
         vote = Citysdk::Vote.new
         vote.assign_attributes(params.permit(:service_request_id, :author, :privacy_policy_accepted))

--- a/app/controllers/citysdk/requests_controller.rb
+++ b/app/controllers/citysdk/requests_controller.rb
@@ -101,6 +101,7 @@ module Citysdk
 
     # :apidoc: ### Update Service request
     # :apidoc: <code>PATCH http://[API endpoint]/requests/[service_request_id].[format]</code>
+    # :apidoc:
     # :apidoc: <code>PUT   http://[API endpoint]/requests/[service_request_id].[format]</code>
     # :apidoc:
     # :apidoc: Parameters:

--- a/app/controllers/citysdk/requests_controller.rb
+++ b/app/controllers/citysdk/requests_controller.rb
@@ -100,9 +100,10 @@ module Citysdk
     end
 
     # :apidoc: ### Update Service request
-    # :apidoc: <code>PATCH http://[API endpoint]/requests/[service_request_id].[format]</code>
-    # :apidoc:
-    # :apidoc: <code>PUT   http://[API endpoint]/requests/[service_request_id].[format]</code>
+    # :apidoc: ```
+    # :apidoc: PATCH http://[API endpoint]/requests/[service_request_id].[format]
+    # :apidoc: PUT   http://[API endpoint]/requests/[service_request_id].[format]
+    # :apidoc: ```
     # :apidoc:
     # :apidoc: Parameters:
     # :apidoc:
@@ -117,14 +118,15 @@ module Citysdk
     # :apidoc: | address_string | * | String | Address for position |
     # :apidoc: | photo_required | - | Boolean | Photo required |
     # :apidoc: | media | - | String | Photo as Base64 encoded string |
-    # :apidoc: | detailed_status | - | String | Status (RECEIVED, IN_PROCESS, PROCESSED, REJECTED) |
+    # :apidoc: | detailed_status | - | String | CitySDK status |
     # :apidoc: | status_notes | - | String | Status note |
     # :apidoc: | priority | - | Integer | Priority |
     # :apidoc: | delegation | - | String | Delegation to external role |
     # :apidoc: | job_status | - | Integer | Job status |
     # :apidoc: | job_priority | - | Integer | Job priority |
     # :apidoc:
-    # :apidoc: *: Either `lat` and `long` or `address_string` are required
+    # :apidoc: *: Either `lat` and `long` or `address_string` are required\
+    # :apidoc: Available CitySDK states for this action: `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
     # :apidoc:
     # :apidoc: Sample Response:
     # :apidoc:

--- a/app/controllers/citysdk/requests_controller.rb
+++ b/app/controllers/citysdk/requests_controller.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
+# require 'citysdk/requests_controller/index'
 module Citysdk
   class RequestsController < CitysdkController
-    include Index
+    include RequestsController::Index
 
-    #  skip_before_action :validate_service_request_id, only: :index
     before_action :encode_params, only: %i[create update]
 
-    # Einzelner Vorgang nach ID
-    # params:
-    #   service_request_id  pflicht  - Vorgang-ID
-    #   api_key             optional - API-Key
-    #   extensions          optional - Response mit erweitereten Attributsausgaben
+    # :apidoc: Einzelner Vorgang nach ID
+    # :apidoc: params:
+    # :apidoc:   service_request_id  pflicht  - Vorgang-ID
+    # :apidoc:   api_key             optional - API-Key
+    # :apidoc:   extensions          optional - Response mit erweitereten Attributsausgaben
     def show
       @request = Citysdk::Request.authorized(tips: authorized?(:read_tips)).where(id: params[:id])
       citysdk_response @request, root: :service_requests, element_name: :request,
@@ -42,6 +42,31 @@ module Citysdk
 
       citysdk_response request, root: :service_requests, element_name: :request, show_only_id: true, status: :created
     end
+
+    # ### Update Service Request
+    # <code>http://[API endpoint]/requests/[service_request_id].[format]</code>
+    #
+    # HTTP Method: PUT / PATCH
+    #
+    # Parameters:
+    #
+    # | Name | Required | Type | Notes |
+    # |:--|:-:|:-:|:-:|
+    # | api_key | X | String | API-Key |
+    # | email | X | String | Author-Email |
+    # | service_code | - | Integer | Category-ID |
+    # | description | - | String | Description |
+    # | lat | - | Float | either lat & long or address_string |
+    # | long | - | Float | either lat & long or address_string |
+    # | address_string | - | String | either address_string or lat & long |
+    # | photo_required | - | Boolean | Photo required |
+    # | detailed_status | - | String | Status (RECEIVED, IN_PROCESS, PROCESSED, REJECTED) |
+    # | status_notes | - | String | Status note |
+    # | priority | - | Integer | Priority |
+    # | delegation | - | String | Delegation to external role |
+    # | job_status | - | Integer | Job status |
+    # | job_priority | - | Integer | Job priority |
+    # | media | - | String | Photo (Base64-Encoded-String) |
 
     # Vorgang aktualisieren
     # params:

--- a/app/controllers/citysdk/requests_controller/index.rb
+++ b/app/controllers/citysdk/requests_controller/index.rb
@@ -5,29 +5,63 @@ module Citysdk
     module Index
       extend ActiveSupport::Concern
 
-      # Liste von Vorgaengen
-      # params:
-      #   api_key             optional - API-Key
-      #   service_request_id  optional - Filter: Vorgangs-IDs(Kommaliste)
-      #   service_code        optional - Filter: Kategorie-ID
-      #   status              optional - Filter: Vorgangsstatus (Options: default=open, closed)
-      #   detailed_status     optional - Filter: Vorgangsstatus (Options: PENDING, RECEIVED, IN_PROCESS, PROCESSED,
-      #                                                                   REJECTED)
-      #   start_date          optional - Filter: Meldungsdatum >= date
-      #   end_date            optional - Filter: Meldungsdatum <= date
-      #   updated_after       optional - Filter vorgang.version >= date
-      #   updated_before      optional - Filter vorgang.version <= date
-      #   agency_responsible  optional - Filter vorgang.auftrag.team
-      #   extensions          optional - Response mit erweitereten Attributsausgaben
-      #   lat                 optional - Schraenkt den Bereich ein, in dem gesucht wird (benoetigt: lat, long & radius)
-      #   long                optional - Schraenkt den Bereich ein, in dem gesucht wird (benoetigt: lat, long & radius)
-      #   radius              optional - Schraenkt den Bereich ein, in dem gesucht wird (benoetigt: lat, long & radius)
-      #   keyword             optional - Filter: Meldungstyp (Problem|Idee|Tipp)
-      #   max_requests        optional - Anzahl der neuesten Meldungen
-      #   also_archived       optional - Filter: Auch Archivierte Meldungen beruecksichtigen
-      #   just_count          optional - es soll nur die Anzahl der Meldungen zurueckgegeben werden
-      #   observation_key     optional - MD5-Hash der zugehoerigen Beobachtungsflaeche
-      #   with_picture        optional - Filter: Meldungen mit freigegebenen Fotos
+      # :apidoc: ### Get service requests list
+      # :apidoc: <code>GET http://[API endpoint]/requests.[format]</code>
+      # :apidoc:
+      # :apidoc: Parameters:
+      # :apidoc:
+      # :apidoc: | Name | Required | Type | Notes |
+      # :apidoc: |:--|:-:|:--|:--|
+      # :apidoc: | api_key | - | String | API key |
+      # :apidoc: | service_request_id | - | Integer / String | List of multiple Request-IDs, comma delimited |
+      # :apidoc: | service_code | - | Integer | ID of category |
+      # :apidoc: | status | - | String | Filter issues by Open311 status, default = `open` |
+      # :apidoc: | detailed_status |  - | String | Filter issues by CitySDK status |
+      # :apidoc: | start_date | - | Date | Filter for issue date >= value, e.g 2011-01-01T00:00:00Z |
+      # :apidoc: | end_date | - | Date | Filter for isse date <= value, e.g 2011-01-01T00:00:00Z |
+      # :apidoc: | updated_after | - | Date | Filter for issue version >= value, e.g 2011-01-01T00:00:00Z |
+      # :apidoc: | updated_before | - | Date | Filter for issue version <= value, e.g 2011-01-01T00:00:00Z |
+      # :apidoc: | agency_responsible | - | String | Filter for issues by job team |
+      # :apidoc: | extensions | - | Boolean | Include extended attributs in response |
+      # :apidoc: | lat | - | Double | Filter restriction area (lat, long and radius required) |
+      # :apidoc: | long | - | Double | Filter restriction area (lat, long and radius required) |
+      # :apidoc: | radius | - | Double | Meter to filter restriction area (lat, long and radius required) |
+      # :apidoc: | keyword | - | String | Filter issues by kind, options: problem, idea, tip |
+      # :apidoc: | with_picture | - | Boolean | Filter issues with released photos |
+      # :apidoc: | also_archived | - | Boolean | Include already archived issues |
+      # :apidoc: | just_count | - | Boolean | Switch response to only return amount of affected issues |
+      # :apidoc: | max_requests | - | Integer | Maximum number of requests to return |
+      # :apidoc: | observation_key | - | String | MD5 hash of observed area to use as filter |
+      # :apidoc: | area_code | - | Integer | Filter issues by affected area ID |
+      # :apidoc:
+      # :apidoc: Available Open311 states: `open`, `closed`
+      # :apidoc: Available CitySDK states: `PENDING`, `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
+      # :apidoc:
+      # :apidoc: Sample Response:
+      # :apidoc:
+      # :apidoc: ```xml
+      # :apidoc: <service_requests type="array">
+      # :apidoc:   <request>
+      # :apidoc:     <service_request_id>request.id</service_request_id>
+      # :apidoc:     <status_notes/>
+      # :apidoc:     <status>request.status</status>
+      # :apidoc:     <service_code>request.service.code</service_code>
+      # :apidoc:     <service_name>request.service.name</service_name>
+      # :apidoc:     <description>request.description</description>
+      # :apidoc:     <agency_responsible>request.agency_responsible</agency_responsible>
+      # :apidoc:     <service_notice/>
+      # :apidoc:     <requested_datetime>request.requested_datetime</requested_datetime>
+      # :apidoc:     <updated_datetime>request.updated_datetime</updated_datetime>
+      # :apidoc:     <expected_datetime/>
+      # :apidoc:     <address>request.address</address>
+      # :apidoc:     <adress_id/>
+      # :apidoc:     <lat>request.position.lat</lat>
+      # :apidoc:     <long>request.position.lat</long>
+      # :apidoc:     <media_url/>
+      # :apidoc:     <zipcode/>
+      # :apidoc:   </request>
+      # :apidoc: </service_requests>
+      # :apidoc: ```
       def index
         return index_just_counts if params[:just_count].present?
 

--- a/app/controllers/citysdk/requests_controller/index.rb
+++ b/app/controllers/citysdk/requests_controller/index.rb
@@ -34,8 +34,8 @@ module Citysdk
       # :apidoc: | observation_key | - | String | MD5 hash of observed area to use as filter |
       # :apidoc: | area_code | - | Integer | Filter issues by affected area ID |
       # :apidoc:
-      # :apidoc: Available Open311 states: `open`, `closed`
-      # :apidoc: Available CitySDK states: `PENDING`, `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
+      # :apidoc: Available Open311 states for this action: `open`, `closed`\
+      # :apidoc: Available CitySDK states for this action: `PENDING`, `RECEIVED`, `IN_PROCESS`, `PROCESSED`, `REJECTED`
       # :apidoc:
       # :apidoc: Sample Response:
       # :apidoc:

--- a/app/controllers/citysdk/services_controller.rb
+++ b/app/controllers/citysdk/services_controller.rb
@@ -2,11 +2,57 @@
 
 module Citysdk
   class ServicesController < CitysdkController
+    # :apidoc: ### GET services list
+    # :apidoc: <code>GET http://[API endpoint]/services.[format]</code>
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | - | String | API key |
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <services type="array">
+    # :apidoc:   <service>
+    # :apidoc:     <service_code>category.id</service_code>
+    # :apidoc:     <service_name>category.name</service_name>
+    # :apidoc:     <description/>
+    # :apidoc:     <metadata>false</metadata>
+    # :apidoc:     <type>realtime</type>
+    # :apidoc:     <keywords>category.parent.typ [problem|idee|tipp]</keywords>
+    # :apidoc:     <group>category.parent.name</group>
+    # :apidoc:   </service>
+    # :apidoc: </services>
+    # :apidoc: ```
     def index
       citysdk_response(sorted,
         { root: :services, element_name: :service, document_url: authorized?(:citysdk_d3_document_url) })
     end
 
+    # :apidoc: ### Get service definition
+    # :apidoc: <code>GET http://[API endpoint]/services/[id].[format]</code>
+    # :apidoc:
+    # :apidoc: Parameters:
+    # :apidoc:
+    # :apidoc: | Name | Required | Type | Notes |
+    # :apidoc: |:--|:-:|:--|:--|
+    # :apidoc: | api_key | - | String | API key |
+    # :apidoc: | id | X | Integer | ID of service|
+    # :apidoc:
+    # :apidoc: Sample Response:
+    # :apidoc:
+    # :apidoc: ```xml
+    # :apidoc: <service_definition type="array">
+    # :apidoc:   <service>
+    # :apidoc:     <service_code>category.id</service_code>
+    # :apidoc:     <service_name>category.name</service_name>
+    # :apidoc:     <keywords>category.parent.typ [problem|idee|tipp]</keywords>
+    # :apidoc:     <group>category.parent.name</group>
+    # :apidoc:   </service>
+    # :apidoc: </service_definition>
+    # :apidoc: ```
     def show
       service_definition = Citysdk::ServiceDefinition.where(id: params[:id])
       citysdk_response(service_definition, root: :service_definition, element_name: :service,

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
-  api!
   def show
     @comment = Comment.find(params[:id])
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
+  api!
   def show
     @comment = Comment.find(params[:id])
   end

--- a/lib/tasks/citysdk_api_doc.rake
+++ b/lib/tasks/citysdk_api_doc.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+namespace :citysdk do
+  desc 'Create API documentation CitySDK_API.md'
+  task apidoc: :environment do
+    api = [<<~API]
+      # Klarschiff-CitySDK
+      Implementation of CitySDK-Smart-Participation-API for Klarschiff
+
+      ## Supported formats and encoding
+      The API supports both JSON and XML. All strings are encoded with UTF-8.
+
+      ## General info
+      The Issue Reporting API is based on GeoReport API version 2, better known as the [Open311 specification](http://open311.org/).
+      The interface is designed in such a way that any GeoReport v2 compatible client is able to use the interface.
+      This interface is compliant with [CitySDK](http://www.citysdk.eu/) specific enhancements to Open311.
+      To support some special functions there are also some additional enhancements to Open311 and CitySDK.
+
+      ## API methods
+    API
+    Dir.glob('app/controllers/citysdk/**/*.rb').each { |f| api += extract_documentation(f) }
+    api[-1] = "#{api.last}\n"
+    File.write Rails.root.join('CitySDK_API.md'), api.join("\n")
+  end
+
+  def extract_documentation(file)
+    pattern = /^ *# :apidoc: /
+    lines = File.readlines(file).select { |line| line.match? pattern }
+    lines.map! { |line| line.remove pattern }
+    lines.map! &:strip
+    lines << '' unless lines.length.zero?
+    lines
+  end
+end

--- a/lib/tasks/citysdk_api_doc.rake
+++ b/lib/tasks/citysdk_api_doc.rake
@@ -18,17 +18,29 @@ namespace :citysdk do
 
       ## API methods
     API
-    Dir.glob('app/controllers/citysdk/**/*.rb').each { |f| api += extract_documentation(f) }
+    input_files.each { |f| api += extract_documentation(f) }
     api[-1] = "#{api.last}\n"
     File.write Rails.root.join('CitySDK_API.md'), api.join("\n")
   end
+end
 
-  def extract_documentation(file)
-    pattern = /^ *# :apidoc: ?/
-    lines = File.readlines(file).select { |line| line.match? pattern }
-    lines.map! { |line| line.remove pattern }
-    lines.map!(&:strip)
-    lines << '' unless lines.length.zero?
-    lines
-  end
+private
+
+def extract_documentation(file)
+  pattern = /^ *# :apidoc: ?/
+  lines = File.readlines(file).select { |line| line.match? pattern }
+  lines.map! { |line| line.remove pattern }
+  lines.map!(&:rstrip)
+  lines << '' unless lines.length.zero?
+  lines
+end
+
+def input_files
+  path_prefix = 'app/controllers/citysdk'
+  %w[
+    discovery_controller.rb
+    services_controller.rb
+    requests_controller/index.rb
+    requests_controller.rb
+  ].map { |f| "#{path_prefix}/#{f}" } | Dir.glob("#{path_prefix}/**/*.rb")
 end

--- a/lib/tasks/citysdk_api_doc.rake
+++ b/lib/tasks/citysdk_api_doc.rake
@@ -27,7 +27,7 @@ namespace :citysdk do
     pattern = /^ *# :apidoc: ?/
     lines = File.readlines(file).select { |line| line.match? pattern }
     lines.map! { |line| line.remove pattern }
-    lines.map! &:strip
+    lines.map!(&:strip)
     lines << '' unless lines.length.zero?
     lines
   end

--- a/lib/tasks/citysdk_api_doc.rake
+++ b/lib/tasks/citysdk_api_doc.rake
@@ -24,7 +24,7 @@ namespace :citysdk do
   end
 
   def extract_documentation(file)
-    pattern = /^ *# :apidoc: /
+    pattern = /^ *# :apidoc: ?/
     lines = File.readlines(file).select { |line| line.match? pattern }
     lines.map! { |line| line.remove pattern }
     lines.map! &:strip


### PR DESCRIPTION
Erzeugung der CitySDK API Dokumentation. 

Manueller Aufruf via `rails citysdk:apidoc`, automatisierter Aufruf durch Github Workflow Action bei Erstellung eines PR.