### PR TITLE
Anfrageoptimierung bei Dashboard-Anfragen

### DIFF
--- a/app/models/issue/scopes.rb
+++ b/app/models/issue/scopes.rb
@@ -71,7 +71,7 @@ class Issue
       end
 
       def authorized_by_areas_for(group_ids)
-        reference_ids = Group.active.where(id: group_ids).pluck(:reference_id).uniq
+        reference_ids = Group.active.where(id: group_ids).distinct.pluck(:reference_id)
         return none if reference_ids.blank?
         where <<~SQL.squish, reference_ids, reference_ids
           ST_Within("position", (

--- a/app/models/issue/scopes.rb
+++ b/app/models/issue/scopes.rb
@@ -71,7 +71,7 @@ class Issue
       end
 
       def authorized_by_areas_for(group_ids)
-        reference_ids = Group.active.where(id: group_ids).pluck(:reference_id)
+        reference_ids = Group.active.where(id: group_ids).pluck(:reference_id).uniq
         return none if reference_ids.blank?
         where <<~SQL.squish, reference_ids, reference_ids
           ST_Within("position", (


### PR DESCRIPTION
ID-Duplikate in den Subqueries zu `county` und `authority` vermieden.

Alt: `SELECT COUNT(*) FROM "issue" WHERE (ST_Within("position", ( SELECT
ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
FROM "county" WHERE "id" IN
(3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3) )) OR
ST_Within("position", ( SELECT
ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
FROM "authority" WHERE "id" IN
(3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3) ))) AND [...]`

Neu: `SELECT COUNT(*) FROM "issue" WHERE (ST_Within("position", ( SELECT
ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
FROM "county" WHERE "id" IN (3) )) OR ST_Within("position", ( SELECT
ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
FROM "authority" WHERE "id" IN (3) ))) AND [...]`