### PR TITLE
Unterstützung von mehreren Werten für Keyword-Filter

### DIFF
--- a/app/controllers/citysdk/citysdk_controller/parameter_validation.rb
+++ b/app/controllers/citysdk/citysdk_controller/parameter_validation.rb
@@ -25,7 +25,7 @@ module Citysdk
       def validate_keyword
         keywords = %w[problem idea]
         keywords << 'tip' if authorized?(:read_tips)
-        return if (keyword = params[:keyword]).blank? || keyword.in?(keywords)
+        return if (keyword = params[:keyword]).blank? || keyword.split(/, ?/).all? { |kw| kw.in?(keywords) }
         raise 'keyword invalid'
       end
 

--- a/test/controllers/citysdk/requests_controller_test.rb
+++ b/test/controllers/citysdk/requests_controller_test.rb
@@ -86,6 +86,14 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'index with keyword filter list' do
+    keywords = %w[idea problem]
+    get "/citysdk/requests.json?extensions=true&api_key=#{api_key_frontend}&keyword=#{keywords.join ','}"
+    assert_response :success
+    assert_not_empty(list = response.parsed_body)
+    assert(list.all? { |issue| Issue.find(issue['service_request_id']).kind.in? keywords })
+  end
+
   test 'reject index with keyword tip for unpermitted clients' do
     get "/citysdk/requests.json?extensions=true&api_key=#{api_key_frontend}&keyword=tip"
     assert_response :error


### PR DESCRIPTION
Die ursprünglich mit #198 ergänzter Validierung hatte nur Einzelwerte und keine gemäß Spezifikation / API erlaubte kommaseparierte Liste unterstützt. Dies wird hiermit nachgeholt.