### PR TITLE
ArelTable Concern auf Dateibasis

### DIFF
--- a/app/controllers/concerns/arel_table.rb
+++ b/app/controllers/concerns/arel_table.rb
@@ -5,7 +5,8 @@ module ArelTable
 
   private
 
-  ActiveRecord::Base.connection.tables.each do |table|
+  Dir['app/models/**/*.rb'].each do |table|
+    table.sub!('app/models/', '').sub!('.rb', '').tr!('/', '_')
     define_method "#{table}_arel_table" do
       table.camelize.constantize.arel_table
     end

--- a/app/controllers/concerns/arel_table.rb
+++ b/app/controllers/concerns/arel_table.rb
@@ -5,10 +5,15 @@ module ArelTable
 
   private
 
-  Dir['app/models/**/*.rb'].each do |table|
-    table.sub!('app/models/', '').sub!('.rb', '').tr!('/', '_')
-    define_method "#{table}_arel_table" do
-      table.camelize.constantize.arel_table
+  Dir['app/models/*.rb'].each do |file_name|
+    classes = File.readlines(file_name).filter_map do |line|
+      next unless (match_data = /class (.*) < ApplicationRecord$/.match(line))
+      match_data[1]
+    end
+    classes.each do |class_name|
+      define_method "#{class_name.underscore}_arel_table" do
+        class_name.constantize.arel_table
+      end
     end
   end
 end


### PR DESCRIPTION
Anlegen der ArelTable Funktion nicht mehr über eine Datenbankanfrage um den Fehler beim initialisieren zu verhindern, da zum Zaitpunkt der Initialisierung die Umgebungsvariable noch nicht berücksichtig wird.