### PR TITLE
Redmine #4003: Keine Statusänderung ohne öffentlichen Statuskommentar setzbar

### DIFF
--- a/app/models/issue/callbacks.rb
+++ b/app/models/issue/callbacks.rb
@@ -33,7 +33,10 @@ class Issue
       validates :status_note, length: { maximum: Settings::Issue.status_note_max_length }
       validates :status_note, presence: true, if: :expected_closure_changed?
       validates :status_note, presence: true, on: :update,
-        if: -> { status_changed? && status.to_i > Issue.statuses[:reviewed] }
+        if: lambda {
+              status_changed? && !default_group_without_gui_access? &&
+                Issue.statuses[status] > Issue.statuses[:reviewed]
+            }
     end
 
     private

--- a/app/views/issues/_tab_master_data.html.erb
+++ b/app/views/issues/_tab_master_data.html.erb
@@ -23,13 +23,13 @@
             class: 'form-control',
             maxlength: Settings::Issue.status_note_max_length,
             rows: 5,
-            readonly: restricted || form.object.closed?
+            readonly: restricted || (!form.object.status_changed? && form.object.closed?)
           ) %>
       <%= select_tag :status_note_template,
             options_for_select(status_note_templates),
             class: 'form-select',
             prompt: 'Vorlage wählen',
-            disabled: restricted || form.object.closed? %>
+            disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
     </div>
   </div>
 <% end -%>
@@ -39,7 +39,8 @@
     <% MainCategory.kinds.each do |kind, ix| -%>
       <div class="form-check form-check-inline">
         <%= form.label("kind_#{kind}", '', class: 'form-check-label') do %>
-          <%= form.radio_button :kind, kind, disabled: restricted || form.object.closed? %>
+          <%= form.radio_button :kind, kind,
+                disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
           <%= MainCategory.human_enum_name :kind, kind %>
         <% end %>
       </div>
@@ -50,31 +51,35 @@
   <%= form.label :category, for: :issue_main_user_id, class: 'col-2 col-form-label' %>
   <div class="col-4">
     <%= form.select :category_id, grouped_categories(form.object),
-          { include_blank: true }, class: 'form-select', disabled: restricted || form.object.closed? %>
+          { include_blank: true }, class: 'form-select',
+          disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
   </div>
   <%= form.label :author, class: 'col-1 col-form-label' %>
   <div class="col-5">
     <%= form.text_field :author,
           class: 'form-control',
           value: form.object.new_record? ? Current.user.email : form.object.author,
-          readonly: !form.object.new_record? || restricted || form.object.closed? %>
+          readonly: !form.object.new_record? || restricted || (!form.object.status_changed? && form.object.closed?) %>
   </div>
 </div>
 <div class="row">
   <%= form.label :description, class: 'col-2 col-form-label' %>
   <div class="col-<%= form.object.new_record? ? 10 : 9 %>">
-    <%= form.text_area :description, class: 'form-control', rows: 5, disabled: restricted || form.object.closed? %>
+    <%= form.text_area :description, class: 'form-control', rows: 5,
+          disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
   </div>
   <% unless form.object.new_record? -%>
     <div class="col-1">
       <%= form.label :description_status_internal, '',
             class: 'form-check-label', title: description_status_internal_title do %>
-        <%= form.radio_button :description_status, :internal, disabled: restricted || form.object.closed? %>
+        <%= form.radio_button :description_status, :internal,
+              disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
         <%= tag.span class: 'fa fa-home fa-2x' %>
       <% end -%>
       <%= form.label :description_status_external, '',
             class: 'form-check-label', title: description_status_external_title do %>
-        <%= form.radio_button :description_status, :external, disabled: restricted || form.object.closed? %>
+        <%= form.radio_button :description_status, :external,
+              disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
         <%= tag.span class: 'fa fa-globe fa-2x' %>
       <% end %>
     </div>
@@ -86,7 +91,7 @@
     <%= form.text_field :expected_closure,
           class: 'form-control datepicker',
           value: l(form.object.expected_closure),
-          readonly: restricted || form.object.closed? %>
+          readonly: restricted || (!form.object.status_changed? && form.object.closed?) %>
   </div>
 </div>
 <% unless form.object.new_record? -%>
@@ -96,7 +101,8 @@
       <% Issue.priorities.each do |priority, ix| -%>
         <div class="form-check form-check-inline">
           <%= form.label "priority_#{priority}", '', class: 'form-check-label' do %>
-            <%= form.radio_button :priority, priority, disabled: restricted || form.object.closed? %>
+            <%= form.radio_button :priority, priority,
+                  disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
             <%= Issue.human_enum_name :priority, priority %>
           <% end %>
         </div>

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -144,4 +144,19 @@ class IssueTest < ActiveSupport::TestCase
     assert_not_nil value
     assert_not_empty value
   end
+
+  test 'ensure status not changed without status_note' do
+    issue = issue(:reviewed)
+    issue.update status: :not_solvable, status_note: ''
+    assert_not issue.valid?
+    assert_equal [{ error: :blank }], issue.errors.details[:status_note]
+  end
+
+  test 'ensure status can be changed without status_note with auth_code without gui' do
+    issue = issue(:reviewed)
+    issue.stub :default_group_without_gui_access?, true do
+      issue.update status: :not_solvable, status_note: ''
+      assert issue.valid?
+    end
+  end
 end


### PR DESCRIPTION
Statusänderungen sollen nach der erfolgter Erstsichtung grundsätzlich immer mit einem öffentlichen Statuskommentar versehen sein.