### PR TITLE
Datenschutzvorgaben und Vorlagen für öffentliche Statuskommentare

### DIFF
--- a/app/controllers/issue_exports_controller.rb
+++ b/app/controllers/issue_exports_controller.rb
@@ -6,9 +6,12 @@ class IssueExportsController < ApplicationController
   def create
     @issue = Issue.find(params[:issue_id])
     @map_image = Base64.decode64(params[:map_image])
-    kit = PDFKit.new(render_to_string(template: 'issue_exports/create', formats: :html, layout: false),
+    res = params[:restricted].try(:to_boolean) if params[:restricted].present?
+    kit = PDFKit.new(
+      render_to_string(template: 'issue_exports/create', formats: :html, layout: false, locals: { restricted: res }),
       root_url: "#{request.base_url}/", page_size: 'A4', margin_top: '0.5in', margin_right: '0.5in',
-      margin_bottom: '0.5in', margin_left: '0.5in')
+      margin_bottom: '0.5in', margin_left: '0.5in'
+    )
     headers['X-FileName'] = (file_name = "meldung-#{@issue.id}.pdf")
     send_data kit.to_pdf, filename: file_name, disposition: :attachment
   end

--- a/app/controllers/issue_exports_controller.rb
+++ b/app/controllers/issue_exports_controller.rb
@@ -6,13 +6,18 @@ class IssueExportsController < ApplicationController
   def create
     @issue = Issue.find(params[:issue_id])
     @map_image = Base64.decode64(params[:map_image])
-    res = params[:restricted].try(:to_boolean) if params[:restricted].present?
-    kit = PDFKit.new(
-      render_to_string(template: 'issue_exports/create', formats: :html, layout: false, locals: { restricted: res }),
+    headers['X-FileName'] = (file_name = "meldung-#{@issue.id}.pdf")
+    send_data pdf, filename: file_name, disposition: :attachment
+  end
+
+  private
+
+  def pdf
+    PDFKit.new(
+      render_to_string(template: 'issue_exports/create', formats: :html, layout: false,
+        locals: { restricted: params[:restricted]&.to_boolean }),
       root_url: "#{request.base_url}/", page_size: 'A4', margin_top: '0.5in', margin_right: '0.5in',
       margin_bottom: '0.5in', margin_left: '0.5in'
-    )
-    headers['X-FileName'] = (file_name = "meldung-#{@issue.id}.pdf")
-    send_data kit.to_pdf, filename: file_name, disposition: :attachment
+    ).to_pdf
   end
 end

--- a/app/views/delegations/_edit.html.erb
+++ b/app/views/delegations/_edit.html.erb
@@ -7,7 +7,7 @@
         <h1><%= Issue.model_name.human %> <%= t 'edit' %></h1>
         <div class="col text-end">
           <%= link_to tag.i(class: 'fa fa-print btn btn-outline-secondary'),
-                issue_issue_exports_path(@issue),
+                issue_issue_exports_path(@issue, :restricted => true),
                 target: :_blank, id: :issue_export, title: 'PDF mit Daten der Meldung erzeugen', rel: :noopener %>
         </div>
         <div id="print-map" class="print-map"

--- a/app/views/delegations/_edit.html.erb
+++ b/app/views/delegations/_edit.html.erb
@@ -1,5 +1,5 @@
 <div class="modal-dialog modal-xl">
-  <% opts = { url: delegation_path(@issue), remote: true, html: { 'data-dependencies': data_dependencies_path } } %>
+  <% opts = { url: delegation_path(@issue), remote: true, html: { 'data-dependencies': data_dependencies_path } } -%>
   <%= form_for @issue, opts do |f| %>
     <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
     <div class="modal-content">
@@ -7,7 +7,7 @@
         <h1><%= Issue.model_name.human %> <%= t 'edit' %></h1>
         <div class="col text-end">
           <%= link_to tag.i(class: 'fa fa-print btn btn-outline-secondary'),
-                issue_issue_exports_path(@issue, :restricted => true),
+                delegation_export_path(@issue),
                 target: :_blank, id: :issue_export, title: 'PDF mit Daten der Meldung erzeugen', rel: :noopener %>
         </div>
         <div id="print-map" class="print-map"

--- a/app/views/issue_exports/create.html.erb
+++ b/app/views/issue_exports/create.html.erb
@@ -58,20 +58,22 @@
           </td>
         </tr>
 
-        <tr>
-          <td class="label">
-            <%= Issue.human_attribute_name(:created_at) %>
-          </td>
-          <td>
-            <%= l(@issue.created_at, format: :no_seconds) %>
-          </td>
-          <td class="label">
-            <%= Issue.human_attribute_name(:author) %>
-          </td>
-          <td>
-            <%= @issue.author %>
-          </td>
-        </tr>
+        <% unless restricted -%>
+          <tr>
+            <td class="label">
+              <%= Issue.human_attribute_name(:created_at) %>
+            </td>
+            <td>
+              <%= l(@issue.created_at, format: :no_seconds) %>
+            </td>
+            <td class="label">
+              <%= Issue.human_attribute_name(:author) %>
+            </td>
+            <td>
+              <%= @issue.author %>
+            </td>
+          </tr>
+        <% end -%>
 
         <tr>
           <td class="label">

--- a/app/views/issues/_edit.html.erb
+++ b/app/views/issues/_edit.html.erb
@@ -14,7 +14,7 @@
                   issue_issue_email_path(@issue),
                   id: :issue_email_direct, title: 'Daten der Meldung als E-Mail aus eigenem E-Mail-Client versenden' %>
             <%= link_to tag.i(class: 'fa fa-print btn btn-outline-secondary'),
-                  issue_issue_exports_path(@issue),
+                  issue_export_path(@issue),
                   target: :_blank, id: :issue_export, title: 'PDF mit Daten der Meldung erzeugen', rel: :noopener %>
             <% if authorized?(:resend_responsibility, @issue) -%>
               <%= link_to tag.i(class: 'fa fa-paper-plane btn btn-primary'),

--- a/app/views/issues/_tab_master_data.html.erb
+++ b/app/views/issues/_tab_master_data.html.erb
@@ -54,13 +54,15 @@
           { include_blank: true }, class: 'form-select',
           disabled: restricted || (!form.object.status_changed? && form.object.closed?) %>
   </div>
-  <%= form.label :author, class: 'col-1 col-form-label' %>
-  <div class="col-5">
-    <%= form.text_field :author,
-          class: 'form-control',
-          value: form.object.new_record? ? Current.user.email : form.object.author,
-          readonly: !form.object.new_record? || restricted || (!form.object.status_changed? && form.object.closed?) %>
-  </div>
+  <% unless restricted -%>
+    <%= form.label :author, class: 'col-1 col-form-label' %>
+    <div class="col-5">
+      <%= form.text_field :author,
+            class: 'form-control',
+            value: form.object.new_record? ? Current.user.email : form.object.author,
+            readonly: !form.object.new_record? || restricted || (!form.object.status_changed? && form.object.closed?) %>
+    </div>
+  <% end -%>
 </div>
 <div class="row">
   <%= form.label :description, class: 'col-2 col-form-label' %>

--- a/app/views/issues/_tab_photo.html.erb
+++ b/app/views/issues/_tab_photo.html.erb
@@ -3,7 +3,7 @@
     <thead>
       <tr>
         <th scope="col"><%= Photo.human_attribute_name :file %></th>
-        <th scope="col"><%= Photo.human_attribute_name :author %></th>
+        <% unless restricted -%><th scope="col"><%= Photo.human_attribute_name :author %></th><% end -%>
         <th scope="col"><%= Photo.human_attribute_name :approval_status %></th>
         <th scope="col"><%= Photo.human_attribute_name :created_at %></th>
         <% unless restricted || form.object.closed? -%><th scope="col"><%= Photo.human_attribute_name :action %></th><% end -%>
@@ -38,7 +38,11 @@
                       target: '_blank', rel: :noopener %>
               </div>
             </td>
-            <td><%= photo_form.object.author %></td>
+            <% unless restricted -%>
+              <td>
+                <%= photo_form.object.author %>
+              </td>
+            <% end -%>
             <td>
               <%= photo_form.label 'status_internal', '',
                     title: Photo.human_enum_name(:status, :internal),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,6 @@ Rails.application.routes.draw do
     resources :issues do
       get :resend_responsibility
       resource :issue_email, only: %i[new create show]
-      resources :issue_exports, only: %i[create], defaults: { format: :pdf }
     end
     resources :log_entries, only: %i[index]
     resources :mail_blacklists
@@ -83,6 +82,10 @@ Rails.application.routes.draw do
 
   get 'logout', to: 'logins#destroy', as: :logout
   get 'issues/:auth_code/set_status', to: 'issues#set_status', as: :set_issue_status
+  post 'delegations/:issue_id/export.pdf', to: 'issue_exports#create',
+    defaults: { format: :pdf, restricted: 'true' }, as: :delegation_export
+  post 'issues/:issue_id/export.pdf', to: 'issue_exports#create',
+    defaults: { format: :pdf }, as: :issue_export
   put 'update_password', to: 'users#update_password', as: :update_password
   root 'dashboards#show'
 end

--- a/config/status_note_template.sample.yml
+++ b/config/status_note_template.sample.yml
@@ -4,4 +4,3 @@ Lichtraumprofil: Die Einschränkung der Durchgangsbreite ist noch nicht wesentli
 Pflegeerfordernis: Ihr Hinweis ist berechtigt. Er wird in die turnusmäßige Pflege/Säuberung eingeordnet.
 Pflegezustand: Ihr Hinweis ist nicht berechtigt. Der Pflegezustand/Reinigungszustand entspricht der Pflegestandard-Einstufung.
 Unmut: Ihr Hinweis zielt auf übergeordnete kommunalpolitische Belange ab. Eine Bearbeitung ist uns mittels dieses Mediums nicht möglich.
-Zuständigkeit: Widerspruch zwischen Meldungsposition und Inhalt der Meldung. Bitte erstellen Sie eine neue Meldung an der richtigen Position.

--- a/config/status_note_template.sample.yml
+++ b/config/status_note_template.sample.yml
@@ -4,3 +4,4 @@ Lichtraumprofil: Die Einschränkung der Durchgangsbreite ist noch nicht wesentli
 Pflegeerfordernis: Ihr Hinweis ist berechtigt. Er wird in die turnusmäßige Pflege/Säuberung eingeordnet.
 Pflegezustand: Ihr Hinweis ist nicht berechtigt. Der Pflegezustand/Reinigungszustand entspricht der Pflegestandard-Einstufung.
 Unmut: Ihr Hinweis zielt auf übergeordnete kommunalpolitische Belange ab. Eine Bearbeitung ist uns mittels dieses Mediums nicht möglich.
+Zuständigkeit: Widerspruch zwischen Meldungsposition und Inhalt der Meldung. Bitte erstellen Sie eine neue Meldung an der richtigen Position.

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -139,7 +139,7 @@ class IssueTest < ActiveSupport::TestCase
     assert_empty Issue.authorized(user(:editor2))
   end
 
-  test 'ensure status not template value for responibility' do
+  test 'ensure status_note_template value for responibility' do
     value = Config.for(:status_note_template, env: nil)['Zuständigkeit']
     assert_not_nil value
     assert_not_empty value


### PR DESCRIPTION
* externe Rollen dürfen Autor nicht sehen
* Vorlage für öffentlichen Statuskommentar entfernt, da inflationär genutzt