### PR TITLE
Finetuning Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,11 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "monthly"
-    
+      interval: "weekly"
+    ignore:
+      - dependency-name: "bootstrap"
+        versions: [">= 5.2", "< 6"]
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,8 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        if: ${{ ! contains(steps.metadata.outputs.dependency-names, 'bootstrap') }}
+        run: gh pr merge --auto --rebase --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
* wöchentliche Überprüfung der Gems
* Boostrap nur eingeschränkt aktualisieren und grundsätzlich manuell annehmen