### PR TITLE
Ticket #64: Meldung beim Deaktivieren einer Gruppe

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -98,7 +98,7 @@ class Group < ApplicationRecord
   end
 
   def no_associated_categories
-    return unless Category.joins(:responsibilities).exists?(responsibility: { group_id: id })
+    return unless Category.joins(:responsibilities).exists?(responsibility: { group_id: id, deleted_at: nil })
     errors.add :base, :associated_categories
   end
 end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -251,6 +251,7 @@ de:
     county: Landkreis/kreisfreie Stadt
     created_at: Zeitstempel
     deleted: gelöscht
+    deleted_at: Löschzeit
     file: Datei
     id: '#'
     instance: Instanz

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -18,6 +18,20 @@ class GroupTest < ActiveSupport::TestCase
     assert_not group.reload.active
   end
 
+  test 'do not deactivate group with active responsibilities' do
+    group = group(:one)
+    assert_valid group
+    assert_not group.update(active: false)
+  end
+
+  test 'deactivate group with inactive responsibilities' do
+    group = group(:one)
+    assert_valid group
+    assert responsibility(:one).update(deleted_at: Time.current)
+    assert group.update(active: false)
+    assert_not group.reload.active
+  end
+
   test 'authorized scope' do
     assert_equal Group.ids, Group.authorized(user(:admin)).ids
     assert_empty Group.authorized(user(:editor))

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -30,7 +30,7 @@ class GroupTest < ActiveSupport::TestCase
     group = group(:one)
     assert_valid group
     assert responsibility(:one).update(deleted_at: Time.current)
-    assert group.active?
+    assert_predicate group, :active?
     assert group.update(active: false)
     assert_not group.reload.active?
   end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -21,15 +21,18 @@ class GroupTest < ActiveSupport::TestCase
   test 'do not deactivate group with active responsibilities' do
     group = group(:one)
     assert_valid group
-    assert_not group.update(active: false)
+    group.active = false
+    assert_not group.valid?
+    assert_equal [{ error: :associated_categories }], group.errors.details[:base]
   end
 
   test 'deactivate group with inactive responsibilities' do
     group = group(:one)
     assert_valid group
     assert responsibility(:one).update(deleted_at: Time.current)
+    assert group.active?
     assert group.update(active: false)
-    assert_not group.reload.active
+    assert_not group.reload.active?
   end
 
   test 'authorized scope' do


### PR DESCRIPTION
Validierung der zugewiesenen Zuständigkeiten zu einer Gruppe beim Versuch diese zu deaktivieren darf sich nur auf nicht gelöschte / deaktivierte Zuständigkeiten beziehen.
Hintergrund: Deaktivierte (gelöschte) Gruppen mit zugewiesenen Zuständigkeiten führen zu Fehlern bei Bearbeitung der zugehörigen Meldungen. Diese können durch die Nutzer nicht mehr geöffnet / gefunden werden, nur noch durch Admins. Das galt es zu verhindern 
(Trac Ticket #64).