### PR TITLE
Verbesserung der Positionsgenauigkeit

### DIFF
--- a/app/models/citysdk/request_filter.rb
+++ b/app/models/citysdk/request_filter.rb
@@ -51,7 +51,7 @@ module Citysdk
     def default_filter_area(params)
       return if (lat = params[:lat]).blank? || (long = params[:long]).blank? || (radius = params[:radius]).blank?
       @collection = @collection.where(<<~SQL.squish, lat:, long:, radius: radius.to_f / 100_000)
-        (#{Issue.quoted_table_name}."position" &&
+        ST_Within(#{Issue.quoted_table_name}."position",
           ST_Buffer(ST_SetSRID(ST_MakePoint(:lat, :long), 4326), :radius))
       SQL
     end
@@ -104,14 +104,14 @@ module Citysdk
       return @collection = @collection.none unless obs
       @collection = @collection.where(category_id: obs.category_ids.split(',').map(&:to_i))
       @collection = @collection.where(<<~SQL.squish)
-        (#{Issue.quoted_table_name}."position" &&
+        ST_Within(#{Issue.quoted_table_name}."position",
           (#{Observation.where(key: params[:observation_key]).select(:area).to_sql}))
       SQL
     end
 
     def filter_area_code(params)
       @collection = @collection.where(<<~SQL.squish)
-        (#{Issue.quoted_table_name}."position" &&
+        ST_Within(#{Issue.quoted_table_name}."position",
           (#{Settings.area_level.where(id: params[:area_code].to_i).select(:area).to_sql}))
       SQL
     end

--- a/app/models/concerns/regional_scope.rb
+++ b/app/models/concerns/regional_scope.rb
@@ -5,7 +5,7 @@ module RegionalScope
 
   class_methods do
     def regional(lat:, lon:)
-      where('(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) && "area")', lat: lat.to_f, lon: lon.to_f)
+      where('ST_Within(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326), "area")', lat: lat.to_f, lon: lon.to_f)
     end
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -39,9 +39,9 @@ class Group < ApplicationRecord
         LEFT JOIN #{county_tn} "c" ON "c"."id" = #{group_tn}."reference_id" AND #{group_tn}."type" = 'CountyGroup'
         LEFT JOIN #{instance_tn} "i" ON "i"."id" = #{group_tn}."reference_id" AND #{group_tn}."type" = 'InstanceGroup'
       JOIN
-        (ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) && "a"."area") OR
-        (ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) && "c"."area") OR
-        (ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) && "i"."area")
+        ST_Within(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326), "a"."area") OR
+        ST_Within(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326), "c"."area") OR
+        ST_Within(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326), "i"."area")
       SQL
     end
 

--- a/app/models/issue/scopes.rb
+++ b/app/models/issue/scopes.rb
@@ -49,7 +49,7 @@ class Issue
       def authorized_by_user_districts(user = Current.user)
         return all if user.blank? || user.districts.blank?
         where <<~SQL.squish, user.district_ids
-          ("position" && (
+          ST_Within("position", (
             SELECT ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
             FROM #{District.quoted_table_name}
             WHERE "id" IN (?)
@@ -82,10 +82,11 @@ class Issue
 
       def authorized_by_references(reference_ids)
         where <<~SQL.squish, reference_ids, reference_ids
-          ("position" && (
+          ST_Within("position", (
             SELECT ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
-            FROM #{County.quoted_table_name} WHERE "id" IN (?)
-          )) OR ("position" && (
+            FROM #{County.quoted_table_name}
+            WHERE "id" IN (?)
+          )) OR ST_Within("position", (
             SELECT ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
             FROM #{Authority.quoted_table_name} WHERE "id" IN (?)
           ))

--- a/app/models/issue_filter/extended_filter.rb
+++ b/app/models/issue_filter/extended_filter.rb
@@ -53,7 +53,7 @@ class IssueFilter
 
     def districts_sql
       <<-SQL.squish
-        ("position" && (
+        ST_Within("position", (
           SELECT ST_Multi(ST_CollectionExtract(ST_Polygonize(ST_Boundary("area")), 3))
           FROM #{District.quoted_table_name}
           WHERE "id" IN (?)


### PR DESCRIPTION
Nutzung von `ST_Within` statt `&&` zur Vermeidung fehlerhafter Ergebnisse auf Grund von ausschließlichen BBox-Treffern durch Index-Vergleichen