### PR TITLE
Ticket #49: Validierung Dateigröße

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -17,7 +17,7 @@ class Photo < ApplicationRecord
   attr_accessor :censor_width, :censor_height, :skip_email_notification
 
   before_validation :set_author, on: :create
-  validates :file, attached: true, content_type: 'image/jpeg', on: :create
+  validates :file, attached: true, content_type: 'image/jpeg', size: { greater_than: 0 }, on: :create
 
   default_scope -> { where.not(confirmed_at: nil) }
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -13,7 +13,7 @@ class Photo < ApplicationRecord
 
   attr_reader :censor_rectangles
 
-  enum status: { internal: 0, external: 1, deleted: 2 }, _prefix: true
+  enum :status, { internal: 0, external: 1, deleted: 2 }, prefix: true
 
   belongs_to :issue
 

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -7,19 +7,21 @@ class Photo < ApplicationRecord
   include ConfirmationWithHash
   include Logging
 
+  default_scope -> { where.not(confirmed_at: nil) }
+
+  attr_accessor :censor_width, :censor_height, :skip_email_notification
+
+  attr_reader :censor_rectangles
+
   enum status: { internal: 0, external: 1, deleted: 2 }, _prefix: true
 
   belongs_to :issue
 
   has_one_attached :file
 
-  attr_reader :censor_rectangles
-  attr_accessor :censor_width, :censor_height, :skip_email_notification
-
-  before_validation :set_author, on: :create
   validates :file, attached: true, content_type: 'image/jpeg', size: { greater_than: 0 }, on: :create
 
-  default_scope -> { where.not(confirmed_at: nil) }
+  before_validation :set_author, on: :create
 
   def _modification
     nil

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -146,6 +146,10 @@ de:
             position:
               outside_instance: befindet sich außerhalb des gültigen Bereichs.
               outside_of_designated_districts: befindet sich außerhalb Ihres Zuständigkeitsbereichs.
+        photo:
+          attributes:
+            file:
+              file_size_not_greater_than: "muss größer als %{min_size} sein (aktuelle Dateigröße ist %{file_size})"
         responsibility:
           attributes:
             base:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -149,7 +149,7 @@ de:
         photo:
           attributes:
             file:
-              file_size_not_greater_than: "muss größer als %{min_size} sein (aktuelle Dateigröße ist %{file_size})"
+              file_size_not_greater_than: "ist ungültig und kann nicht verarbeitet werden (ist leer / hat keinen Inhalt)"
         responsibility:
           attributes:
             base:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -301,6 +301,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_082321) do
     t.geometry "area", limit: {:srid=>4326, :type=>"multi_polygon"}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["area"], name: "index_observation_on_area", using: :gist
   end
 
   create_table "photo", force: :cascade do |t|

--- a/test/models/photo_test.rb
+++ b/test/models/photo_test.rb
@@ -26,9 +26,21 @@ class PhotoTest < ActiveSupport::TestCase
     assert_empty photo.errors.details[:author]
   end
 
+  test 'validate file size' do
+    photo = Photo.new(file: empty_file)
+    assert_not photo.valid?
+    assert_equal [{ error: :file_size_not_greater_than, greater_than: 0, validator_type: :size,
+                    filename: 'empty.jpg', min_size: '0 Bytes', file_size: '0 Bytes', max_size: nil }],
+      photo.errors.details[:file]
+  end
+
   private
 
   def test_file
     Rack::Test::UploadedFile.new(Rails.root.join('test/fixtures/files/test.jpg'), 'image/jpeg')
+  end
+
+  def empty_file
+    Rack::Test::UploadedFile.new(Rails.root.join('test/fixtures/files/empty.jpg'), 'image/jpeg')
   end
 end


### PR DESCRIPTION
Vermeidung von `redirect#show (Vips::Error) "VipsForeignLoad: ...` Fehlern beim Anzeigeversuch von Bildern ohne Inhalt / leerer Datei im Upload (Trac Ticket #49)