### PR TITLE
Ausgabe aller Meldungen im Excel-Export

### DIFF
--- a/app/models/issue_filter.rb
+++ b/app/models/issue_filter.rb
@@ -17,12 +17,12 @@ class IssueFilter
     [
       Category.arel_table[:id], 'delegation_issue.id', Group.arel_table[:id],
       Issue.arel_table[:id], Job.arel_table[:id], MainCategory.arel_table[:id],
-      Photo.arel_table[:id], SubCategory.arel_table[:id], AbuseReport.arel_table[:id]
+      SubCategory.arel_table[:id], AbuseReport.arel_table[:id]
     ]
   end
 
   def includes
-    [:abuse_reports, :group, :delegation, :job, :photos, { category: %i[main_category sub_category] }]
+    [:abuse_reports, :group, :delegation, :job, { category: %i[main_category sub_category] }]
   end
 
   def filter_collection(params, extended_filter)


### PR DESCRIPTION
Die Photos wurden unnötiger Weise in den Anfragen mit eingeschlossen, wodurch der `JOIN` zu einer Vermehrfachung der Issues im Resultset führte, was wiederum durch das `find_each` zum Abbruch der weiteren Datenholung führte. Daher wurden die Photos aus der Anfrage entfernt.