### PR TITLE
Ausgabe aller Meldungen im Excel-Export

### DIFF
--- a/app/models/issue_filter.rb
+++ b/app/models/issue_filter.rb
@@ -15,14 +15,14 @@ class IssueFilter
 
   def group_by
     [
-      Category.arel_table[:id], 'delegation_issue.id', Group.arel_table[:id],
-      Issue.arel_table[:id], Job.arel_table[:id], MainCategory.arel_table[:id],
-      SubCategory.arel_table[:id], AbuseReport.arel_table[:id]
+      Category.arel_table[:id], Group.arel_table[:id],
+      Issue.arel_table[:id], MainCategory.arel_table[:id],
+      SubCategory.arel_table[:id]
     ]
   end
 
   def includes
-    [:abuse_reports, :group, :delegation, :job, { category: %i[main_category sub_category] }]
+    [:group, { category: %i[main_category sub_category] }]
   end
 
   def filter_collection(params, extended_filter)

--- a/app/models/issue_filter/extended_filter.rb
+++ b/app/models/issue_filter/extended_filter.rb
@@ -83,11 +83,11 @@ class IssueFilter
     end
 
     def filter_begin_at(params)
-      @collection = @collection.where(iat[:created_at].gteq(params[:begin_at]))
+      @collection = @collection.where(iat[:created_at].gteq(Date.parse(params[:begin_at]).beginning_of_day))
     end
 
     def filter_end_at(params)
-      @collection = @collection.where(iat[:created_at].lteq(params[:end_at]))
+      @collection = @collection.where(iat[:created_at].lteq(Date.parse(params[:end_at]).end_of_day))
     end
 
     def text_conds(term)


### PR DESCRIPTION
Das gleiche Problem wie in #522 trat ebenfalls bei vorhandenen Missbrauchsmeldungen sowie Delegationen und Aufträgen auf. Daher wurden auch diese aus dem `JOIN` entfernt.

Zusätzlich erfolgt eine Anpassung der zeitlichen Filter: Beginn und Ende werden auf den Tages-Anfang bzw. das Tages-Ende des angegebenen Datums gefiltert. Andernfalls wurde immer die aktuelle Export-Uhrzeit genutzt und damit gab es ebenfalls noch Abweichungen in den Ergebnissen.