### PR TITLE
Kategorien löschen ermöglichen

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,7 +17,8 @@ class Category < ApplicationRecord
   delegate :dms_link, :name, to: :sub_category, prefix: true
 
   def self.active
-    eager_load(:main_category, :sub_category).where main_category: { deleted: false }, sub_category: { deleted: false }
+    where(deleted_at: nil).eager_load(:main_category, :sub_category).where main_category: { deleted: false },
+      sub_category: { deleted: false }
   end
 
   def to_s

--- a/db/migrate/20250314074534_add_deleted_at_to_category.rb
+++ b/db/migrate/20250314074534_add_deleted_at_to_category.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToCategory < ActiveRecord::Migration[7.2]
+  def change
+    add_column :category, :deleted_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_30_082321) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_14_074534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_082321) do
     t.datetime "updated_at", null: false
     t.bigint "main_category_id"
     t.bigint "sub_category_id"
+    t.datetime "deleted_at", precision: nil
     t.index ["main_category_id", "sub_category_id"], name: "index_category_on_main_category_id_and_sub_category_id", unique: true
     t.index ["main_category_id"], name: "index_category_on_main_category_id"
     t.index ["sub_category_id"], name: "index_category_on_sub_category_id"

--- a/test/fixtures/category.yml
+++ b/test/fixtures/category.yml
@@ -1,5 +1,6 @@
 DEFAULTS: &DEFAULTS
   average_turnaround_time: 3
+  deleted_at:
   main_category: $LABEL
   sub_category: $LABEL
 
@@ -14,6 +15,12 @@ three:
 
 deleted:
   <<: *DEFAULTS
+
+deleted_at:
+  <<: *DEFAULTS
+  deleted_at: 2025-01-23T15:25:00+0100
+  main_category: one
+  sub_category: two
 
 deleted_main_category:
   <<: *DEFAULTS

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -3,7 +3,13 @@
 require 'test_helper'
 
 class CategoryTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'scope acvtive contains no soft deleted categories' do
+    deleted_category = category(:deleted_at)
+    assert_not deleted_category.main_category.deleted?
+    assert_not deleted_category.sub_category.deleted?
+    assert deleted_category.deleted_at
+    assert_not_includes Category.active, deleted_category
+    assert deleted_category.update(deleted_at: nil)
+    assert_includes Category.active, deleted_category
+  end
 end


### PR DESCRIPTION
und gelöschte Kategorien aus dem `active` Scope ausschließen.