### PR TITLE
Redmine #4874: Einschränkung der via CitySDK ausgelieferten Meldungen

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -16,7 +16,7 @@ class Category < ApplicationRecord
   delegate :dms_link, :name, to: :sub_category, prefix: true
 
   def self.active
-    where(deleted_at: nil).eager_load(:main_category, :sub_category).where main_category: { deleted: false },
+    eager_load(:main_category, :sub_category).where deleted_at: nil, main_category: { deleted: false },
       sub_category: { deleted: false }
   end
 

--- a/app/models/citysdk/request.rb
+++ b/app/models/citysdk/request.rb
@@ -19,9 +19,17 @@ module Citysdk
     alias_attribute :service_request_id, :id
     alias_attribute :status_notes, :status_note
 
-    def self.authorized(tips:)
-      return all if tips
-      includes(category: :main_category).where.not main_category: { kind: :tip }
+    class << self
+      def authorized(tips:)
+        return active if tips
+        active.includes(category: :main_category).where.not main_category: { kind: :tip }
+      end
+
+      private
+
+      def active
+        where category_id: Service.active
+      end
     end
 
     def assign_attributes(attributes)

--- a/test/controllers/citysdk/requests_controller_test.rb
+++ b/test/controllers/citysdk/requests_controller_test.rb
@@ -70,6 +70,13 @@ class RequestsControllerTest < ActionDispatch::IntegrationTest
     assert_predicate extended_attributes, :blank?
   end
 
+  test 'index with valid api-key never returns requests for deleted services' do
+    get "/citysdk/requests.json?extensions=true&api_key=#{api_key_frontend}"
+    assert_not_empty(list = response.parsed_body)
+    assert_not_empty(service_codes = list.pluck('service_code'))
+    assert_not_includes service_codes, category(:deleted_at).id
+  end
+
   test 'index with extensions and area_code for authorities with api-key frontend' do
     with_parent_instance_settings do
       get "/citysdk/requests.xml?extensions=true&area_code=#{authority(:one).id}&api_key=#{api_key_frontend}"

--- a/test/fixtures/issue.yml
+++ b/test/fixtures/issue.yml
@@ -170,3 +170,7 @@ reference_default: &REFERENCE_DEFAULT
 
 reference_default_county:
   <<: *REFERENCE_DEFAULT
+
+deleted_category:
+  <<: *DEFAULTS
+  category: deleted_at

--- a/test/models/citysdk/request_test.rb
+++ b/test/models/citysdk/request_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Citysdk
+  class RequestTest < ActiveSupport::TestCase
+    test 'scope authorized contains no objects with soft deleted categories' do
+      deleted_category = category(:deleted_at)
+      assert Request.exists?(category_id: deleted_category.id)
+      assert_not Request.authorized(tips: false).exists?(category_id: deleted_category.id)
+      assert_not Request.authorized(tips: true).exists?(category_id: deleted_category.id)
+    end
+  end
+end


### PR DESCRIPTION
… zum Ausschluss von gelöschten Kategorien und damit der Vermeidung von fehlenden `Service` Daten im Client, da der `Request` sonst auf Objekte verweist die vom Server nicht ausgeliefert werden.