### PR TITLE
Fix for code scanning alert for URL redirection from remote source

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -16,16 +16,29 @@ class CategoriesController < ApplicationController
   def reactivate
     @category = Category.find(params[:id])
     @category.update!(deleted_at: nil)
-    redirect_to permitted_order_and_pagination_params.merge(action: :index)
+    redirect_to safe_redirect_params
   end
 
   def destroy
     @category = Category.active.find(params[:id])
     @category.update!(deleted_at: Time.current)
-    redirect_to permitted_order_and_pagination_params.merge(action: :index)
+    redirect_to safe_redirect_params
   end
 
   private
+
+  # Only allow redirection with sanitized parameters.
+  def safe_redirect_params
+    page = Integer(params[:page] || 1) rescue 1
+    filter = (params[:filter] || {}).permit(:include_inactive, :text)
+    order_by = (params[:order_by] || {}).permit(:column, :dir)
+    {
+      action: :index,
+      page: page,
+      filter: filter.to_h.slice('include_inactive', 'text'),
+      order_by: order_by.to_h.slice('column', 'dir')
+    }
+  end
 
   def filter(collection)
     filter_include_inactive(super)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -28,11 +28,14 @@ class CategoriesController < ApplicationController
   private
 
   def safe_redirect_params
-    page = (p = params[:page].to_i).positive? ? p : 1
-    params.permit(
+    safe_params = params.permit(
       filter: %i[include_inactive text],
       order_by: %i[column dir]
-    ).to_h.merge(page: page)
+    ).to_h
+    if (page = params[:page].to_i).positive?
+      safe_params[:page] = page
+    end
+    safe_params
   end
 
   def filter(collection)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -16,13 +16,13 @@ class CategoriesController < ApplicationController
   def reactivate
     @category = Category.find(params[:id])
     @category.update!(deleted_at: nil)
-    redirect_to safe_redirect_params
+    redirect_to categories_path(safe_redirect_params)
   end
 
   def destroy
     @category = Category.active.find(params[:id])
     @category.update!(deleted_at: Time.current)
-    redirect_to safe_redirect_params
+    redirect_to categories_path(safe_redirect_params)
   end
 
   private
@@ -32,7 +32,7 @@ class CategoriesController < ApplicationController
     params.permit(
       filter: [:include_inactive, :text],
       order_by: [:column, :dir]
-    ).to_h.merge(action: :index, page: page)
+    ).to_h.merge(page: page)
   end
 
   def filter(collection)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -30,8 +30,8 @@ class CategoriesController < ApplicationController
   def safe_redirect_params
     page = (p = params[:page].to_i).positive? ? p : 1
     params.permit(
-      filter: [:include_inactive, :text],
-      order_by: [:column, :dir]
+      filter: %i[include_inactive text],
+      order_by: %i[column dir]
     ).to_h.merge(page: page)
   end
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -27,17 +27,12 @@ class CategoriesController < ApplicationController
 
   private
 
-  # Only allow redirection with sanitized parameters.
   def safe_redirect_params
-    page = Integer(params[:page] || 1) rescue 1
-    filter = (params[:filter] || {}).permit(:include_inactive, :text)
-    order_by = (params[:order_by] || {}).permit(:column, :dir)
-    {
-      action: :index,
-      page: page,
-      filter: filter.to_h.slice('include_inactive', 'text'),
-      order_by: order_by.to_h.slice('column', 'dir')
-    }
+    page = (p = params[:page].to_i).positive? ? p : 1
+    params.permit(
+      filter: [:include_inactive, :text],
+      order_by: [:column, :dir]
+    ).to_h.merge(action: :index, page: page)
   end
 
   def filter(collection)


### PR DESCRIPTION
Potential fix for [https://github.com/bfpi/klarschiff-backoffice/security/code-scanning/26](https://github.com/bfpi/klarschiff-backoffice/security/code-scanning/26)

To fix the potential open redirect, sanitize or validate the user parameters being merged into the redirect hash. We should ensure only expected values and formats are allowed, especially for keys like `page` and `filter`. Here's the best fix:
- Instead of directly permitting user input for redirection, extract and validate the permitted values (e.g., check that `page` is an integer, `order_by` subkeys are expected column names/dirs, etc.).
- Construct a safe hash for redirection, not directly from raw params, but from sanitized/validated values.
- Update both instances (`reactivate` and `destroy` actions) that use `permitted_order_and_pagination_params.merge(action: :index)` in calls to `redirect_to`.

Specifically:
- Add new helper methods (`safe_redirect_params`) that extract and sanitize relevant permitted params for redirection.
- Replace `redirect_to permitted_order_and_pagination_params.merge(action: :index)` with `redirect_to safe_redirect_params`.
- No new external dependencies needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
