### PR TITLE
CitySDK-Areas ohne Coordinaten

### DIFF
--- a/CitySDK_API.md
+++ b/CitySDK_API.md
@@ -363,6 +363,7 @@ Parameters:
 | search_class | - | String | specifies which data to search for |
 | regional_key | - | Integer / String | RegionalKey to filter region (based on search_class) |
 | with_districts | - | Boolean | return all existing districts, not available if using area_code |
+| skip_coordinates | - | Boolean | set to true to skip border-data to speed up the list |
 
 The parameter `regional_key` is ignored if parameter `area_code` is given with the request, so you have
 to omit the `area_code` parameter to get the response for `regional_key` filter.

--- a/app/controllers/citysdk/areas_controller.rb
+++ b/app/controllers/citysdk/areas_controller.rb
@@ -16,6 +16,7 @@ module Citysdk
     # :apidoc: | search_class | - | String | specifies which data to search for |
     # :apidoc: | regional_key | - | Integer / String | RegionalKey to filter region (based on search_class) |
     # :apidoc: | with_districts | - | Boolean | return all existing districts, not available if using area_code |
+    # :apidoc: | skip_coordinates | - | Boolean | set to true to skip border-data to speed up the list |
     # :apidoc:
     # :apidoc: The parameter `regional_key` is ignored if parameter `area_code` is given with the request, so you have
     # :apidoc: to omit the `area_code` parameter to get the response for `regional_key` filter.
@@ -35,7 +36,8 @@ module Citysdk
     # :apidoc: </areas>
     # :apidoc: ```
     def index
-      citysdk_response limit_response(order_response(search_areas)), { root: :areas, element_name: :area }
+      citysdk_response limit_response(order_response(search_areas)),
+        root: :areas, element_name: :area, skip_coordinates: params[:skip_coordinates].try(:to_boolean)
     end
 
     private

--- a/app/models/citysdk/authority.rb
+++ b/app/models/citysdk/authority.rb
@@ -4,8 +4,13 @@ module Citysdk
   class Authority < ::Authority
     include Citysdk::Serialization
 
-    self.serialization_attributes = %i[id name grenze]
+    self.serialization_attributes = %i[id name]
 
     alias_attribute :grenze, :area
+
+    def serializable_methods(options)
+      return [] if options[:skip_coordinates]
+      [:grenze]
+    end
   end
 end

--- a/app/models/citysdk/district.rb
+++ b/app/models/citysdk/district.rb
@@ -4,8 +4,13 @@ module Citysdk
   class District < ::District
     include Citysdk::Serialization
 
-    self.serialization_attributes = %i[id name grenze]
+    self.serialization_attributes = %i[id name]
 
     alias_attribute :grenze, :area
+
+    def serializable_methods(options)
+      return [] if options[:skip_coordinates]
+      [:grenze]
+    end
   end
 end

--- a/test/controllers/citysdk/areas_controller_test.rb
+++ b/test/controllers/citysdk/areas_controller_test.rb
@@ -30,6 +30,7 @@ class AreasControllerTest < ActionDispatch::IntegrationTest
       doc = Nokogiri::XML(response.parsed_body)
       areas = doc.xpath('/areas/area/name/text()').map(&:to_s).select { |t| t.starts_with? 'Authority' }
       assert_predicate areas.count, :positive?
+      assert_equal areas.count, doc.xpath('/areas/area/grenze/text()').count
     end
   end
 
@@ -39,6 +40,27 @@ class AreasControllerTest < ActionDispatch::IntegrationTest
       doc = Nokogiri::XML(response.parsed_body)
       areas = doc.xpath('/areas/area/name/text()').map(&:to_s).select { |t| t.starts_with? 'District' }
       assert_predicate areas.count, :positive?
+      assert_equal areas.count, doc.xpath('/areas/area/grenze/text()').count
+    end
+  end
+
+  test 'index with default area-level and skip coordinates' do
+    with_parent_instance_settings do
+      get '/citysdk/areas.xml', params: { with_districts: true, skip_coordinates: true }
+      doc = Nokogiri::XML(response.parsed_body)
+      areas = doc.xpath('/areas/area/name/text()').map(&:to_s).select { |t| t.starts_with? 'Authority' }
+      assert_predicate areas.count, :positive?
+      assert_empty doc.xpath('/areas/area/grenze/text()')
+    end
+  end
+
+  test 'index with parent_instance area-level and skip coordinates' do
+    with_parent_instance_settings(url: 'http://www.example.com') do
+      get '/citysdk/areas.xml', params: { with_districts: true, skip_coordinates: true }
+      doc = Nokogiri::XML(response.parsed_body)
+      areas = doc.xpath('/areas/area/name/text()').map(&:to_s).select { |t| t.starts_with? 'District' }
+      assert_predicate areas.count, :positive?
+      assert_empty doc.xpath('/areas/area/grenze/text()')
     end
   end
 


### PR DESCRIPTION
Diese Änderung ergänzt eine Option `skip_coordinates` für die Anfrage der Gebiete, um die Ermittlung und Ausgabe der Flächenpolygon-Koordinaten zu überspringen. Damit verringert sich bei großer Flächenanzahl (MV Instanz) die Ladezeit der Statistik auf 1/10 der ursprünglichen Laufzeit.