### PR TITLE
Listensortierungen im Dashboard angepasst; Kleinigkeiten im Impressum

### DIFF
--- a/app/controllers/dashboards_controller/issues.rb
+++ b/app/controllers/dashboards_controller/issues.rb
@@ -17,7 +17,11 @@ class DashboardsController
     def latest_issues
       base_issues.includes({ category: :main_category }).not_archived
         .where(status: %w[received reviewed in_process not_solvable closed])
-        .order(issue_arel_table[:priority].desc, issue_arel_table[:updated_at].desc, issue_arel_table[:id].desc)
+        .order(
+          issue_arel_table[:priority].desc,
+          issue_arel_table[:group_responsibility_notified_at].desc.nulls_last,
+          issue_arel_table[:id].desc
+        )
         .limit(10)
     end
 
@@ -35,8 +39,13 @@ class DashboardsController
 
     def former_issues(groups)
       return [] if groups.blank?
-      Issue.not_archived.joins(:issue_responsibilities).includes(category: :main_category)
-        .where(changed_responsibilities(groups.ids)).distinct.limit 10
+      Issue.not_archived
+        .joins(:issue_responsibilities)
+        .includes(category: :main_category)
+        .where(changed_responsibilities(groups.ids))
+        .distinct
+        .order(updated_at: :desc, id: :asc)
+        .limit(10)
     end
 
     def changed_responsibilities(group_ids)

--- a/app/views/contacts/show.html
+++ b/app/views/contacts/show.html
@@ -1,6 +1,6 @@
 <p>
   Hanse- und Universitätsstadt Rostock<br>
   Kataster-, Vermessungs- und Liegenschaftsamt<br>
-  Holbeinplatz 14<br>
+  An der Jägerbäk 3<br>
   18069 Rostock<br>
 </p>

--- a/app/views/imprints/show.html
+++ b/app/views/imprints/show.html
@@ -4,12 +4,12 @@
     <p>
       Hanse- und Universitätsstadt Rostock<br>
       Kataster-, Vermessungs- und Liegenschaftsamt<br>
-      Holbeinplatz 14<br>
+      An der Jägerbäk 3<br>
       18069 Rostock<br>
     </p>
   </div>
   <div class="col-3 offset-1">
-    <h6>Technische Realisierung</h6>
+    <h6>Technische Umsetzung</h6>
     <p>
       BFPI Büro für praktische Informatik GmbH<br>
       Fleckebyer Str. 1<br>


### PR DESCRIPTION
* Listensortierungen im Dashboard angepasst (im Nachgang von Redmine-Ticket 4869):
  * Liste _Ehemalige Meldungen:_ absteigend sortieren nach Zeitpunkt der „Ehemaligwerdung“
  * Liste _Neueste Meldungen:_ absteigend sortieren nach Zeitpunkt der Erstellung oder Zuweisung
* Kleinigkeiten im Impressum:
  * Adresse des Kataster-, Vermessungs- und Liegenschaftsamts der Hanse- und Universitätsstadt Rostock im Impressum angepasst
  * Adresse des Kataster-, Vermessungs- und Liegenschaftsamts der Hanse- und Universitätsstadt Rostock auf der Kontaktseite angepasst